### PR TITLE
feature/settings

### DIFF
--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/calendar/CalendarAction.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/calendar/CalendarAction.kt
@@ -5,8 +5,8 @@ import studio.lunabee.microgallery.android.data.YearPreview
 
 sealed interface CalendarAction {
 
-    class JumpToSettings : CalendarAction // Jump to settings screen
-    class ResetToHome : CalendarAction // Jump to the year view
+    object JumpToSettings : CalendarAction // Jump to settings screen
+    object ResetToHome : CalendarAction // Jump to the year view
 
     data class ShowPhoto( // Jump to photoViewer screen
         val pictureId: Long,

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/calendar/CalendarScreen.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/calendar/CalendarScreen.kt
@@ -57,7 +57,7 @@ fun CalendarScreen(
 ) {
     Box(modifier = Modifier.fillMaxWidth()) {
         BackHandler(enabled = calendarUiState.yearSelected != null) {
-            fireAction(CalendarAction.ResetToHome())
+            fireAction(CalendarAction.ResetToHome)
         }
         if (calendarUiState.yearSelected != null) {
             ScrollTroughYear(calendarUiState, fireAction)
@@ -66,7 +66,7 @@ fun CalendarScreen(
         }
 
         IconButton(
-            onClick = { fireAction(CalendarAction.JumpToSettings()) },
+            onClick = { fireAction(CalendarAction.JumpToSettings) },
             modifier = Modifier
                 .align(Alignment.TopEnd)
                 .statusBarsPadding(),

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/loading/LoadingAction.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/loading/LoadingAction.kt
@@ -1,7 +1,7 @@
 package studio.lunabee.amicrogallery.loading
 
 sealed interface LoadingAction {
-    class FoundData : LoadingAction
-    class Reload : LoadingAction
+    object FoundData : LoadingAction
+    object Reload : LoadingAction
     data class Error(val errorMessage: String?) : LoadingAction
 }

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/loading/LoadingPresenter.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/loading/LoadingPresenter.kt
@@ -23,10 +23,11 @@ class LoadingPresenter(
     }
 
     init {
-        refreshEvent()
+        //refreshDB()
+        emitUserAction(LoadingAction.FoundData())
     }
 
-    private fun refreshEvent() {
+    private fun refreshDB() {
         viewModelScope.launch {
             when (val result: LBResult<Unit> = UpdateTreeUseCase(loadingRepository).invoke()) {
                 is LBResult.Success -> {
@@ -42,7 +43,7 @@ class LoadingPresenter(
 
     private fun onAction(action: LoadingAction) {
         if (action is LoadingAction.Reload) {
-            refreshEvent()
+            refreshDB()
         }
         viewModelScope.launch { emitUserAction(action) }
     }

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/loading/LoadingPresenter.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/loading/LoadingPresenter.kt
@@ -23,15 +23,14 @@ class LoadingPresenter(
     }
 
     init {
-        //refreshDB()
-        emitUserAction(LoadingAction.FoundData())
+        refreshDB()
     }
 
     private fun refreshDB() {
         viewModelScope.launch {
             when (val result: LBResult<Unit> = UpdateTreeUseCase(loadingRepository).invoke()) {
                 is LBResult.Success -> {
-                    emitUserAction(LoadingAction.FoundData())
+                    emitUserAction(LoadingAction.FoundData)
                 }
 
                 is LBResult.Failure<Unit> -> {

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/loading/LoadingScreen.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/loading/LoadingScreen.kt
@@ -6,12 +6,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import studio.lunabee.amicrogallery.android.core.ui.theme.MicroGalleryTheme.colors
 import studio.lunabee.amicrogallery.android.core.ui.theme.MicroGalleryTheme.spacing
 import studio.lunabee.amicrogallery.android.core.ui.theme.MicroGalleryTheme.typography
 import studio.lunabee.amicrogallery.app.R
@@ -39,6 +41,10 @@ fun WaitingForResponse() {
                 style = typography.body,
                 modifier = Modifier.align(Alignment.CenterHorizontally),
             )
+            LinearProgressIndicator(
+                color = colors.main,
+                trackColor = colors.second.copy(alpha = 0.5f),
+            )
         }
     }
 }
@@ -59,7 +65,7 @@ fun ShowError(error: String?, onAction: (LoadingAction) -> Unit) {
                 modifier = Modifier.padding(spacing.SpacingSmall),
             )
             Button(
-                onClick = { onAction(LoadingAction.Reload()) },
+                onClick = { onAction(LoadingAction.Reload) },
             ) {
                 Text(text = stringResource(R.string.reload))
             }

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsAction.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsAction.kt
@@ -1,5 +1,9 @@
 package studio.lunabee.amicrogallery.settings
 
+import studio.lunabee.microgallery.android.data.SettingsData
+
 sealed interface SettingsAction {
     object JumpBack : SettingsAction
+
+    data class GotData( val data : SettingsData) : SettingsAction
 }

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsAction.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsAction.kt
@@ -1,9 +1,23 @@
 package studio.lunabee.amicrogallery.settings
 
+import android.content.Context
+import studio.lunabee.microgallery.android.data.RemoteStatus
 import studio.lunabee.microgallery.android.data.SettingsData
 
 sealed interface SettingsAction {
     object JumpBack : SettingsAction
 
-    data class GotData( val data : SettingsData) : SettingsAction
+    data class GotData(val data: SettingsData) : SettingsAction
+
+    data class Clear(
+        val context: Context,
+    ) : SettingsAction
+    data class SetParameters(
+        val data: SettingsData,
+    ) : SettingsAction
+
+    object GetRemoteStatus : SettingsAction
+    data class GotRemoteStatus(
+        val status: RemoteStatus,
+    ) : SettingsAction
 }

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsPresenter.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsPresenter.kt
@@ -9,13 +9,17 @@ import studio.lunabee.compose.presenter.LBSingleReducer
 import studio.lunabee.microgallery.android.domain.settings.SettingsRepository
 
 class SettingsPresenter(
-    val settingsRepository: SettingsRepository
+    val settingsRepository: SettingsRepository,
 ) : LBSinglePresenter<SettingsUiState, SettingsNavScope, SettingsAction>() {
     override val flows: List<Flow<SettingsAction>> = emptyList()
 
-    override fun getInitialState(): SettingsUiState = SettingsUiState(data = null)
+    override fun getInitialState(): SettingsUiState = SettingsUiState(
+        data = null,
+        remoteStatus = null,
+    )
 
-    init{
+    init {
+        emitUserAction(SettingsAction.GetRemoteStatus)
         viewModelScope.launch {
             val data = settingsRepository.getSettingsData()
             emitUserAction(SettingsAction.GotData(data = data))
@@ -23,8 +27,8 @@ class SettingsPresenter(
     }
 
     override fun initReducer(): LBSingleReducer<SettingsUiState, SettingsNavScope, SettingsAction> {
-        return SettingsReducer(viewModelScope, ::emitUserAction)
+        return SettingsReducer(viewModelScope, ::emitUserAction, settingsRepository)
     }
 
-    override val content: @Composable ((SettingsUiState) -> Unit) = { SettingsScreen(it,::emitUserAction) }
+    override val content: @Composable ((SettingsUiState) -> Unit) = { SettingsScreen(it, ::emitUserAction) }
 }

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsPresenter.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsPresenter.kt
@@ -3,17 +3,28 @@ package studio.lunabee.amicrogallery.settings
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 import studio.lunabee.compose.presenter.LBSinglePresenter
 import studio.lunabee.compose.presenter.LBSingleReducer
+import studio.lunabee.microgallery.android.domain.settings.SettingsRepository
 
-class SettingsPresenter : LBSinglePresenter<SettingsUiState, SettingsNavScope, SettingsAction>() {
+class SettingsPresenter(
+    val settingsRepository: SettingsRepository
+) : LBSinglePresenter<SettingsUiState, SettingsNavScope, SettingsAction>() {
     override val flows: List<Flow<SettingsAction>> = emptyList()
 
-    override fun getInitialState(): SettingsUiState = SettingsUiState()
+    override fun getInitialState(): SettingsUiState = SettingsUiState(data = null)
+
+    init{
+        viewModelScope.launch {
+            val data = settingsRepository.getSettingsData()
+            emitUserAction(SettingsAction.GotData(data = data))
+        }
+    }
 
     override fun initReducer(): LBSingleReducer<SettingsUiState, SettingsNavScope, SettingsAction> {
         return SettingsReducer(viewModelScope, ::emitUserAction)
     }
 
-    override val content: @Composable ((SettingsUiState) -> Unit) = { SettingsScreen(::emitUserAction) }
+    override val content: @Composable ((SettingsUiState) -> Unit) = { SettingsScreen(it,::emitUserAction) }
 }

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsReducer.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsReducer.kt
@@ -1,14 +1,18 @@
 package studio.lunabee.amicrogallery.settings
 
+import coil3.imageLoader
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import studio.lunabee.compose.presenter.LBSingleReducer
 import studio.lunabee.compose.presenter.ReduceResult
 import studio.lunabee.compose.presenter.asResult
 import studio.lunabee.compose.presenter.withSideEffect
+import studio.lunabee.microgallery.android.domain.settings.SettingsRepository
 
 class SettingsReducer(
     override val coroutineScope: CoroutineScope,
     override val emitUserAction: (SettingsAction) -> Unit,
+    val settingsRepository: SettingsRepository,
 ) : LBSingleReducer<SettingsUiState, SettingsNavScope, SettingsAction> () {
 
     override suspend fun reduce(
@@ -19,12 +23,33 @@ class SettingsReducer(
         return when (action) {
             is SettingsAction.GotData -> actualState.copy(data = action.data).asResult()
             is SettingsAction.JumpBack -> actualState withSideEffect {
+                coroutineScope.launch {
+                    if (actualState.data == null) {
+                        error("Trying to save a null data")
+                    } else {
+                        settingsRepository.setSettingsData(actualState.data)
+                    }
+                }
                 performNavigation {
                     jumpBack()
                 }
             }
+            is SettingsAction.SetParameters -> actualState.copy(data = action.data).asResult()
+            is SettingsAction.Clear -> actualState withSideEffect {
+                coroutineScope.launch {
+                    val imageLoader = action.context.imageLoader
+                    imageLoader.memoryCache?.clear()
+                    settingsRepository.clearDB()
+                }
+            }
 
-
+            is SettingsAction.GotRemoteStatus -> actualState.copy(remoteStatus = action.status).asResult()
+            SettingsAction.GetRemoteStatus -> actualState.withSideEffect {
+                coroutineScope.launch {
+                    val remoteStatus = settingsRepository.getStatus()
+                    emitUserAction(SettingsAction.GotRemoteStatus(remoteStatus))
+                }
+            }
         }
     }
 }

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsReducer.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsReducer.kt
@@ -3,6 +3,7 @@ package studio.lunabee.amicrogallery.settings
 import kotlinx.coroutines.CoroutineScope
 import studio.lunabee.compose.presenter.LBSingleReducer
 import studio.lunabee.compose.presenter.ReduceResult
+import studio.lunabee.compose.presenter.asResult
 import studio.lunabee.compose.presenter.withSideEffect
 
 class SettingsReducer(
@@ -16,11 +17,14 @@ class SettingsReducer(
         performNavigation: (SettingsNavScope.() -> Unit) -> Unit,
     ): ReduceResult<SettingsUiState> {
         return when (action) {
+            is SettingsAction.GotData -> actualState.copy(data = action.data).asResult()
             is SettingsAction.JumpBack -> actualState withSideEffect {
                 performNavigation {
                     jumpBack()
                 }
             }
+
+
         }
     }
 }

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsScreen.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsScreen.kt
@@ -36,6 +36,7 @@ import studio.lunabee.amicrogallery.android.core.ui.theme.MicroGalleryTheme.colo
 import studio.lunabee.amicrogallery.android.core.ui.theme.MicroGalleryTheme.spacing
 import studio.lunabee.amicrogallery.android.core.ui.theme.MicroGalleryTheme.typography
 import studio.lunabee.amicrogallery.app.R
+import studio.lunabee.microgallery.android.data.SettingsData
 import studio.lunabee.amicrogallery.core.ui.R as CoreUi
 
 fun Context.getAppVersion(): String {
@@ -70,7 +71,7 @@ fun TitleSettingsEntry(modifier: Modifier = Modifier, fireAction: (SettingsActio
 }
 
 @Composable
-fun IPAddressesSettingsEntry(modifier: Modifier = Modifier) {
+fun IPAddressesSettingsEntry(modifier: Modifier = Modifier, data : SettingsData) {
     Column(modifier = modifier) {
         Text(
             text = stringResource(R.string.adress_of_server),
@@ -78,7 +79,7 @@ fun IPAddressesSettingsEntry(modifier: Modifier = Modifier) {
         )
 
         OutlinedTextField(
-            value = "",
+            value = data.ipv4,
             singleLine = true,
             shape = shapes.large,
             modifier = Modifier,
@@ -101,7 +102,7 @@ fun IPAddressesSettingsEntry(modifier: Modifier = Modifier) {
         )
 
         OutlinedTextField(
-            value = "",
+            value = data.ipv6,
             singleLine = true,
             shape = shapes.large,
             modifier = Modifier,
@@ -231,35 +232,39 @@ fun ServerStatisticsSettingsEntry(modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun SettingsScreen(fireAction: (SettingsAction) -> Unit) {
-    val settingsEntries: List<@Composable (modifier: Modifier) -> Unit> = listOf(
-        // mod as a short term for modifier
-        { mod -> TitleSettingsEntry(mod, fireAction) },
-        { mod -> IPAddressesSettingsEntry(mod) },
-        { mod -> PreviewSettingsEntry(mod) },
-        { mod -> CacheSettingsEntry(mod) },
-        { mod -> ServerStatisticsSettingsEntry(mod) },
-    )
-    Column(modifier = Modifier.statusBarsPadding()) {
-        val entryModifier = Modifier
-        LazyColumn(
-            modifier = Modifier.background(colors.background),
-            contentPadding = PaddingValues(spacing.SpacingMedium),
-            verticalArrangement = Arrangement.spacedBy(spacing.SpacingLarge),
+fun SettingsScreen(uiState: SettingsUiState, fireAction: (SettingsAction) -> Unit) {
+    if(uiState.data == null)
+        Text(stringResource( R.string.loading), style = typography.body)
+    else {
+        val settingsEntries: List<@Composable (modifier: Modifier) -> Unit> = listOf(
+            // mod as a short term for modifier
+            { mod -> TitleSettingsEntry(mod, fireAction) },
+            { mod -> IPAddressesSettingsEntry(mod, uiState.data) },
+            { mod -> PreviewSettingsEntry(mod) },
+            { mod -> CacheSettingsEntry(mod) },
+            { mod -> ServerStatisticsSettingsEntry(mod) },
+        )
+        Column(modifier = Modifier.statusBarsPadding()) {
+            val entryModifier = Modifier
+            LazyColumn(
+                modifier = Modifier.background(colors.background),
+                contentPadding = PaddingValues(spacing.SpacingMedium),
+                verticalArrangement = Arrangement.spacedBy(spacing.SpacingLarge),
 
-        ) {
-            items(settingsEntries) { entry ->
-                Column {
-                    entry(entryModifier)
-                    Spacer(Modifier.height(spacing.SpacingMedium))
+                ) {
+                items(settingsEntries) { entry ->
+                    Column {
+                        entry(entryModifier)
+                        Spacer(Modifier.height(spacing.SpacingMedium))
+                    }
                 }
             }
-        }
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
-            Text(
-                stringResource(R.string.application_name) + LocalContext.current.getAppVersion(),
-                style = typography.labelBold,
-            )
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+                Text(
+                    stringResource(R.string.application_name) + LocalContext.current.getAppVersion(),
+                    style = typography.labelBold,
+                )
+            }
         }
     }
 }

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsScreen.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsScreen.kt
@@ -1,7 +1,5 @@
 package studio.lunabee.amicrogallery.settings
 
-import android.content.Context
-import android.content.pm.PackageManager
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -10,239 +8,37 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.Button
-import androidx.compose.material3.Checkbox
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme.shapes
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.ImeAction
 import studio.lunabee.amicrogallery.android.core.ui.theme.MicroGalleryTheme.colors
 import studio.lunabee.amicrogallery.android.core.ui.theme.MicroGalleryTheme.spacing
 import studio.lunabee.amicrogallery.android.core.ui.theme.MicroGalleryTheme.typography
 import studio.lunabee.amicrogallery.app.R
-import studio.lunabee.microgallery.android.data.SettingsData
-import studio.lunabee.amicrogallery.core.ui.R as CoreUi
-
-fun Context.getAppVersion(): String {
-    return try {
-        val packageInfo = packageManager.getPackageInfo(packageName, 0)
-        packageInfo.versionName ?: "Unknown"
-    } catch (e: PackageManager.NameNotFoundException) {
-        "Unknown"
-    }
-}
-
-@Composable
-fun TitleSettingsEntry(modifier: Modifier = Modifier, fireAction: (SettingsAction) -> Unit) {
-    Row(modifier = modifier) {
-        IconButton(
-            onClick = { fireAction(SettingsAction.JumpBack) },
-            modifier = modifier.align(Alignment.CenterVertically),
-        ) {
-            Icon(
-                painter = painterResource(CoreUi.drawable.back_arrow),
-                contentDescription = stringResource(R.string.navigate_back),
-                modifier = Modifier.size(spacing.SpacingLarge),
-            )
-        }
-        Spacer(modifier = Modifier.padding(spacing.SpacingSmall))
-        Text(
-            text = stringResource(R.string.settings),
-            style = typography.header,
-            modifier = Modifier.align(alignment = Alignment.CenterVertically),
-        )
-    }
-}
-
-@Composable
-fun IPAddressesSettingsEntry(modifier: Modifier = Modifier, data : SettingsData) {
-    Column(modifier = modifier) {
-        Text(
-            text = stringResource(R.string.adress_of_server),
-            style = typography.title,
-        )
-
-        OutlinedTextField(
-            value = data.ipv4,
-            singleLine = true,
-            shape = shapes.large,
-            modifier = Modifier,
-            colors = TextFieldDefaults.colors(
-                focusedContainerColor = colors.background,
-                unfocusedContainerColor = colors.background,
-                disabledContainerColor = colors.background,
-            ),
-            onValueChange = { newValue: String -> Unit },
-            label = { Text(stringResource(R.string.ipv4), style = typography.body) },
-            isError = false,
-            keyboardOptions = KeyboardOptions.Default.copy(
-                imeAction = ImeAction.Done,
-            ),
-            keyboardActions = KeyboardActions(
-                onDone = {
-                    // TODO : register the new ip
-                },
-            ),
-        )
-
-        OutlinedTextField(
-            value = data.ipv6,
-            singleLine = true,
-            shape = shapes.large,
-            modifier = Modifier,
-            colors = TextFieldDefaults.colors(
-                focusedContainerColor = colors.background,
-                unfocusedContainerColor = colors.background,
-                disabledContainerColor = colors.background,
-            ),
-            onValueChange = { newValue: String -> Unit },
-            label = { Text(stringResource(R.string.ipv6), style = typography.body) },
-            isError = false,
-            keyboardOptions = KeyboardOptions.Default.copy(
-                imeAction = ImeAction.Done,
-            ),
-            keyboardActions = KeyboardActions(
-                onDone = { },
-            ),
-        )
-    }
-}
-
-@Composable
-fun PreviewSettingsEntry(modifier: Modifier = Modifier) {
-    Column(modifier = modifier) {
-        Text(
-            text = stringResource(R.string.previsualisation_options),
-            style = typography.title,
-        )
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-            Column {
-                Text(
-                    text = stringResource(R.string.preview_in_hd),
-                    style = typography.bodyBold,
-                )
-                Text(
-                    text = stringResource(R.string.consumes_more),
-                    style = typography.body,
-                )
-            }
-            Checkbox(
-                modifier = Modifier.align(alignment = Alignment.CenterVertically),
-                checked = true,
-                onCheckedChange = { newValue: Boolean -> Unit },
-            )
-        }
-    }
-}
-
-@Composable
-fun CacheSettingsEntry(modifier: Modifier = Modifier) {
-    Column(modifier = modifier) {
-        Text(
-            text = stringResource(R.string.cache),
-            style = typography.title,
-        )
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-            Column {
-                Text(
-                    text = stringResource(R.string.use_cache),
-                    style = typography.bodyBold,
-                )
-                Text(
-                    text = stringResource(R.string.consume_less_but_more_storage),
-                    style = typography.body,
-                )
-            }
-            Checkbox(
-                modifier = Modifier.align(alignment = Alignment.CenterVertically),
-                checked = true,
-                onCheckedChange = { newValue: Boolean -> Unit },
-            )
-        }
-        Spacer(Modifier.height(spacing.SpacingLarge))
-        Row(horizontalArrangement = Arrangement.Center, modifier = Modifier.fillMaxWidth()) {
-            Button(
-                onClick = {},
-            ) {
-                Text(
-                    text = stringResource(R.string.empty_cache),
-                    style = typography.body,
-                )
-            }
-        }
-    }
-}
-
-@Composable
-fun ServerStatisticsSettingsEntry(modifier: Modifier = Modifier) {
-    Column(modifier = modifier) {
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-            Text(
-                text = stringResource(R.string.server_statistics),
-                style = typography.title,
-                modifier = Modifier.align(alignment = Alignment.CenterVertically),
-            )
-            Button(
-                onClick = {},
-            ) {
-                Text(
-                    text = stringResource(R.string.refresh),
-                    style = typography.body,
-                )
-            }
-        }
-
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-            Text(
-                text = stringResource(R.string.temperature),
-                style = typography.body,
-            )
-            Text(
-                text = stringResource(R.string.celcius, 42),
-                style = typography.body,
-            )
-        }
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-            Text(
-                text = stringResource(R.string.quantity_of_pictures),
-                style = typography.body,
-            )
-            Text(
-                text = stringResource(R.string.nphotos, 14572),
-                style = typography.body,
-            )
-        }
-    }
-}
+import studio.lunabee.amicrogallery.settings.entries.CacheSettingsEntry
+import studio.lunabee.amicrogallery.settings.entries.IPAddressesSettingsEntry
+import studio.lunabee.amicrogallery.settings.entries.ServerStatisticsSettingsEntry
+import studio.lunabee.amicrogallery.settings.entries.TitleSettingsEntry
+import studio.lunabee.amicrogallery.settings.entries.VisualiseSettingsEntry
+import studio.lunabee.amicrogallery.utils.getAppVersion
 
 @Composable
 fun SettingsScreen(uiState: SettingsUiState, fireAction: (SettingsAction) -> Unit) {
-    if(uiState.data == null)
-        Text(stringResource( R.string.loading), style = typography.body)
-    else {
+    if (uiState.data == null) {
+        Text(stringResource(R.string.waitingForData), style = typography.body)
+    } else {
         val settingsEntries: List<@Composable (modifier: Modifier) -> Unit> = listOf(
             // mod as a short term for modifier
             { mod -> TitleSettingsEntry(mod, fireAction) },
-            { mod -> IPAddressesSettingsEntry(mod, uiState.data) },
-            { mod -> PreviewSettingsEntry(mod) },
-            { mod -> CacheSettingsEntry(mod) },
-            { mod -> ServerStatisticsSettingsEntry(mod) },
+            { mod -> IPAddressesSettingsEntry(mod, uiState.data, fireAction) },
+            { mod -> VisualiseSettingsEntry(mod, uiState.data, fireAction) },
+            { mod -> CacheSettingsEntry(mod, fireAction) },
+            { mod -> ServerStatisticsSettingsEntry(mod, uiState.remoteStatus, fireAction) },
         )
         Column(modifier = Modifier.statusBarsPadding()) {
             val entryModifier = Modifier
@@ -251,7 +47,7 @@ fun SettingsScreen(uiState: SettingsUiState, fireAction: (SettingsAction) -> Uni
                 contentPadding = PaddingValues(spacing.SpacingMedium),
                 verticalArrangement = Arrangement.spacedBy(spacing.SpacingLarge),
 
-                ) {
+            ) {
                 items(settingsEntries) { entry ->
                     Column {
                         entry(entryModifier)

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsUiState.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsUiState.kt
@@ -1,6 +1,10 @@
 package studio.lunabee.amicrogallery.settings
 
 import studio.lunabee.compose.presenter.PresenterUiState
+import studio.lunabee.microgallery.android.data.RemoteStatus
 import studio.lunabee.microgallery.android.data.SettingsData
 
-data class SettingsUiState(val data: SettingsData?) : PresenterUiState
+data class SettingsUiState(
+    val data: SettingsData?,
+    val remoteStatus: RemoteStatus?,
+) : PresenterUiState

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsUiState.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsUiState.kt
@@ -1,5 +1,6 @@
 package studio.lunabee.amicrogallery.settings
 
 import studio.lunabee.compose.presenter.PresenterUiState
+import studio.lunabee.microgallery.android.data.SettingsData
 
-class SettingsUiState : PresenterUiState
+data class SettingsUiState(val data: SettingsData?) : PresenterUiState

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/entries/CacheSettingsEntry.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/entries/CacheSettingsEntry.kt
@@ -1,0 +1,41 @@
+package studio.lunabee.amicrogallery.settings.entries
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import studio.lunabee.amicrogallery.android.core.ui.theme.MicroGalleryTheme.typography
+import studio.lunabee.amicrogallery.app.R
+import studio.lunabee.amicrogallery.settings.SettingsAction
+
+@Composable
+fun CacheSettingsEntry(modifier: Modifier = Modifier, fireAction: (SettingsAction) -> Unit) {
+    val context = LocalContext.current
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = stringResource(R.string.cache),
+            style = typography.title,
+        )
+
+        Button(
+            onClick = {
+                fireAction(SettingsAction.Clear(context))
+            },
+        ) {
+            Text(
+                text = stringResource(R.string.empty_cache),
+                style = typography.body,
+            )
+        }
+    }
+}

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/entries/IpAdressesSettingsEntry.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/entries/IpAdressesSettingsEntry.kt
@@ -1,0 +1,118 @@
+package studio.lunabee.amicrogallery.settings.entries
+
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme.shapes
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import studio.lunabee.amicrogallery.android.core.ui.theme.MicroGalleryTheme.colors
+import studio.lunabee.amicrogallery.android.core.ui.theme.MicroGalleryTheme.spacing
+import studio.lunabee.amicrogallery.android.core.ui.theme.MicroGalleryTheme.typography
+import studio.lunabee.amicrogallery.app.R
+import studio.lunabee.amicrogallery.settings.SettingsAction
+import studio.lunabee.amicrogallery.utils.changeCheck
+import studio.lunabee.microgallery.android.data.SettingsData
+
+@Composable
+fun IPAddressesSettingsEntry(modifier: Modifier = Modifier, data: SettingsData, fireAction: (SettingsAction) -> Unit) {
+    var ipv4: String by remember { mutableStateOf(data.ipv4) }
+    var ipv6: String by remember { mutableStateOf(data.ipv6) }
+    var ipv6force: Boolean by remember { mutableStateOf(data.useIpv6) }
+    val keyboardController = LocalSoftwareKeyboardController.current
+    Column(modifier = modifier) {
+        Text(
+            text = stringResource(R.string.adress_of_server),
+            style = typography.title,
+        )
+
+        OutlinedTextField(
+            value = ipv4,
+            singleLine = true,
+            shape = shapes.large,
+            modifier = Modifier,
+            colors = TextFieldDefaults.colors(
+                focusedContainerColor = colors.background,
+                unfocusedContainerColor = colors.background,
+                disabledContainerColor = colors.background,
+            ),
+            onValueChange = { ipv4 = it },
+            label = { Text(stringResource(R.string.ipv4), style = typography.body) },
+            isError = false,
+            keyboardOptions = KeyboardOptions.Default.copy(
+                imeAction = ImeAction.Done,
+            ),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    fireAction(SettingsAction.SetParameters(data.copy(ipv4 = ipv4)))
+                    keyboardController?.hide()
+                },
+            ),
+        )
+
+        OutlinedTextField(
+            value = ipv6,
+            singleLine = true,
+            shape = shapes.large,
+            modifier = Modifier,
+            colors = TextFieldDefaults.colors(
+                focusedContainerColor = colors.background,
+                unfocusedContainerColor = colors.background,
+                disabledContainerColor = colors.background,
+            ),
+            onValueChange = { ipv6 = it },
+            label = { Text(stringResource(R.string.ipv6), style = typography.body) },
+            isError = false,
+            keyboardOptions = KeyboardOptions.Default.copy(
+                imeAction = ImeAction.Done,
+            ),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    fireAction(SettingsAction.SetParameters(data.copy(ipv6 = ipv6)))
+                    keyboardController?.hide()
+                },
+            ),
+        )
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Switch(
+                checked = ipv6force,
+                onCheckedChange = { ipv6force = changeCheck(ipv6force, fireAction, data) },
+            )
+            Spacer(modifier = Modifier.padding(horizontal = spacing.SpacingMedium))
+            Column(
+                modifier = Modifier.pointerInput(null) {
+                    detectTapGestures(
+                        onTap = { ipv6force = changeCheck(ipv6force, fireAction, data) },
+                    )
+                },
+            ) {
+                Text(
+                    text = stringResource(R.string.use_ipv6),
+                    style = typography.labelBold,
+                )
+                Text(
+                    text = stringResource(R.string.wifi_prevention),
+                    style = typography.body,
+                )
+            }
+        }
+    }
+}

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/entries/ServerStatisticsSettingsEntry.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/entries/ServerStatisticsSettingsEntry.kt
@@ -1,0 +1,80 @@
+package studio.lunabee.amicrogallery.settings.entries
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import studio.lunabee.amicrogallery.android.core.ui.theme.MicroGalleryTheme.typography
+import studio.lunabee.amicrogallery.app.R
+import studio.lunabee.amicrogallery.settings.SettingsAction
+import studio.lunabee.microgallery.android.data.RemoteStatus
+
+@Composable
+fun ServerStatisticsSettingsEntry(modifier: Modifier = Modifier, remoteStatus: RemoteStatus?, fireAction: (SettingsAction) -> Unit) {
+    Column(modifier = modifier) {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Text(
+                text = stringResource(R.string.server_statistics),
+                style = typography.title,
+                modifier = Modifier.align(alignment = Alignment.CenterVertically),
+            )
+            Button(
+                onClick = { fireAction(SettingsAction.GetRemoteStatus) },
+            ) {
+                Text(
+                    text = stringResource(R.string.refresh),
+                    style = typography.body,
+                )
+            }
+        }
+        if (remoteStatus == null) {
+            Text(
+                text = stringResource(R.string.waitingForData),
+                style = typography.labelBold,
+            )
+        } else {
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(
+                    text = stringResource(R.string.temperature),
+                    style = typography.body,
+                )
+                Text(
+                    text = stringResource(R.string.celcius, remoteStatus.temperature.toFloat() / 1000.0f),
+                    style = typography.body,
+                )
+            }
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(
+                    text = stringResource(R.string.quantity_of_pictures),
+                    style = typography.body,
+                )
+                Text(
+                    text = stringResource(R.string.nphotos, remoteStatus.quantityHighRes),
+                    style = typography.body,
+                )
+            }
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(
+                    text = stringResource(R.string.quantity_of_pictures_low_res),
+                    style = typography.body,
+                )
+                Text(
+                    text = stringResource(R.string.nphotos, remoteStatus.quantityLowRes),
+                    style = typography.body,
+                )
+            }
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(
+                    text = stringResource(if (remoteStatus.isPlugged) R.string.disk_is_plugged else R.string.disk_not_plugged),
+                    style = typography.body,
+                )
+            }
+        }
+    }
+}

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/entries/TitleSettingsEntry.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/entries/TitleSettingsEntry.kt
@@ -1,0 +1,41 @@
+package studio.lunabee.amicrogallery.settings.entries
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import studio.lunabee.amicrogallery.android.core.ui.theme.MicroGalleryTheme.spacing
+import studio.lunabee.amicrogallery.android.core.ui.theme.MicroGalleryTheme.typography
+import studio.lunabee.amicrogallery.app.R
+import studio.lunabee.amicrogallery.settings.SettingsAction
+import studio.lunabee.amicrogallery.core.ui.R as CoreUi
+
+@Composable
+fun TitleSettingsEntry(modifier: Modifier = Modifier, fireAction: (SettingsAction) -> Unit) {
+    Row(modifier = modifier) {
+        IconButton(
+            onClick = { fireAction(SettingsAction.JumpBack) },
+            modifier = modifier.align(Alignment.CenterVertically),
+        ) {
+            Icon(
+                painter = painterResource(CoreUi.drawable.back_arrow),
+                contentDescription = stringResource(R.string.navigate_back),
+                modifier = Modifier.size(spacing.SpacingLarge),
+            )
+        }
+        Spacer(modifier = Modifier.padding(spacing.SpacingSmall))
+        Text(
+            text = stringResource(R.string.settings),
+            style = typography.header,
+            modifier = Modifier.align(alignment = Alignment.CenterVertically),
+        )
+    }
+}

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/entries/VisualiseEntry.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/entries/VisualiseEntry.kt
@@ -1,0 +1,59 @@
+package studio.lunabee.amicrogallery.settings.entries
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import studio.lunabee.amicrogallery.android.core.ui.theme.MicroGalleryTheme.colors
+import studio.lunabee.amicrogallery.android.core.ui.theme.MicroGalleryTheme.typography
+import studio.lunabee.amicrogallery.app.R
+import studio.lunabee.amicrogallery.settings.SettingsAction
+import studio.lunabee.microgallery.android.data.SettingsData
+
+@Composable
+fun VisualiseSettingsEntry(modifier: Modifier = Modifier, data: SettingsData, fireAction: (SettingsAction) -> Unit) {
+    var viewInHD: Boolean by remember { mutableStateOf(data.viewInHD) }
+    Column(modifier = modifier) {
+        Text(
+            text = stringResource(R.string.visualisation_option),
+            style = typography.title,
+        )
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Column {
+                Text(
+                    text = stringResource(R.string.view_in_hd),
+                    style = typography.labelBold,
+                )
+                Text(
+                    text = stringResource(R.string.consumes_more),
+                    style = typography.body,
+                )
+                if (!viewInHD) {
+                    Text(
+                        text = stringResource(R.string.only_low_res),
+                        style = typography.body,
+                        color = colors.second,
+                    )
+                }
+            }
+            Switch(
+                modifier = Modifier.align(alignment = Alignment.CenterVertically),
+                checked = viewInHD,
+                onCheckedChange = {
+                    viewInHD = !viewInHD
+                    fireAction(SettingsAction.SetParameters(data = data.copy(viewInHD = viewInHD)))
+                },
+            )
+        }
+    }
+}

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/utils/SettingsUtils.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/utils/SettingsUtils.kt
@@ -1,0 +1,21 @@
+package studio.lunabee.amicrogallery.utils
+
+import android.content.Context
+import android.content.pm.PackageManager
+import studio.lunabee.amicrogallery.settings.SettingsAction
+import studio.lunabee.microgallery.android.data.SettingsData
+
+fun Context.getAppVersion(): String {
+    return try {
+        val packageInfo = packageManager.getPackageInfo(packageName, 0)
+        packageInfo.versionName ?: "Unknown"
+    } catch (e: PackageManager.NameNotFoundException) {
+        "Unknown"
+    }
+}
+
+fun changeCheck(ipv6force: Boolean, fireAction: (SettingsAction) -> Unit, data: SettingsData): Boolean {
+    val ipv6forceN = !ipv6force
+    fireAction(SettingsAction.SetParameters(data.copy(useIpv6 = ipv6force)))
+    return ipv6forceN
+}

--- a/microGallery_Android/app/src/main/res/values/strings.xml
+++ b/microGallery_Android/app/src/main/res/values/strings.xml
@@ -37,11 +37,19 @@
     <string name="consume_less_but_more_storage">Consumes less data but use more storage</string>
     <string name="empty_cache">Clear cache</string>
     <string name="server_statistics">Remote statistics</string>
-    <string name="celcius">%d °C</string>
-    <string name="temperature">Temperature:</string>
-    <string name="quantity_of_pictures">"Number of photos: "</string>
+    <string name="celcius">%.2f °C</string>
+    <string name="temperature">Temperature :</string>
+    <string name="quantity_of_pictures">"Number of photos : "</string>
     <string name="nphotos">%,d photos</string>
     <string name="refresh">Refresh</string>
     <string name="navigate_back">Navigate to previous screen</string>
     <string name="select_year">Select a year</string>
+    <string name="use_ipv6">Use IPv6 in priority</string>
+    <string name="wifi_prevention">May not work over certain Wifi</string>
+    <string name="quantity_of_pictures_low_res">Number of photos in fast access :</string>
+    <string name="disk_is_plugged">Disk is plugged</string>
+    <string name="disk_not_plugged">Disk is not plugged</string>
+    <string name="visualisation_option">Viewing options</string>
+    <string name="view_in_hd">View pictures in the highest resolution</string>
+    <string name="only_low_res">Only low resolutions pictures will be visible</string>
 </resources>

--- a/microGallery_Android/core-ui/src/main/kotlin/studio/lunabee/amicrogallery/android/core/ui/theme/CoreTheme.kt
+++ b/microGallery_Android/core-ui/src/main/kotlin/studio/lunabee/amicrogallery/android/core/ui/theme/CoreTheme.kt
@@ -70,6 +70,7 @@ fun mapMaterialColorScheme(
     lightColorScheme(
         primary = coreColors.main,
         onPrimary = coreColors.onMain,
+        secondary = coreColors.second,
         background = coreColors.background,
         onBackground = coreColors.onBackground,
         surface = coreColors.background,

--- a/microGallery_KMP/data/src/commonMain/kotlin/studio/lunabee/microgallery/android/data/RemoteStatus.kt
+++ b/microGallery_KMP/data/src/commonMain/kotlin/studio/lunabee/microgallery/android/data/RemoteStatus.kt
@@ -1,0 +1,8 @@
+package studio.lunabee.microgallery.android.data
+
+data class RemoteStatus(
+    val isPlugged: Boolean, // is usb disk plugged
+    val temperature: Int, // temperature of CPU
+    val quantityHighRes: Int, // number of Pictures in highRes
+    val quantityLowRes: Int, // number of Pictures in lowRes
+)

--- a/microGallery_KMP/data/src/commonMain/kotlin/studio/lunabee/microgallery/android/data/SettingsData.kt
+++ b/microGallery_KMP/data/src/commonMain/kotlin/studio/lunabee/microgallery/android/data/SettingsData.kt
@@ -1,0 +1,6 @@
+package studio.lunabee.microgallery.android.data
+
+data class SettingsData (
+    val ipv4: String,
+    val ipv6: String
+)

--- a/microGallery_KMP/data/src/commonMain/kotlin/studio/lunabee/microgallery/android/data/SettingsData.kt
+++ b/microGallery_KMP/data/src/commonMain/kotlin/studio/lunabee/microgallery/android/data/SettingsData.kt
@@ -1,6 +1,8 @@
 package studio.lunabee.microgallery.android.data
 
-data class SettingsData (
+data class SettingsData(
     val ipv4: String,
-    val ipv6: String
+    val ipv6: String,
+    val useIpv6: Boolean,
+    val viewInHD: Boolean,
 )

--- a/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/settings/SettingsRepository.kt
+++ b/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/settings/SettingsRepository.kt
@@ -1,7 +1,13 @@
 package studio.lunabee.microgallery.android.domain.settings
 
+import studio.lunabee.microgallery.android.data.RemoteStatus
 import studio.lunabee.microgallery.android.data.SettingsData
 
 interface SettingsRepository {
-    suspend fun getSettingsData() : SettingsData
+    suspend fun getSettingsData(): SettingsData
+    suspend fun clearDB()
+
+    suspend fun getStatus(): RemoteStatus
+
+    suspend fun setSettingsData(settingsUiData: SettingsData)
 }

--- a/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/settings/SettingsRepository.kt
+++ b/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/settings/SettingsRepository.kt
@@ -1,0 +1,7 @@
+package studio.lunabee.microgallery.android.domain.settings
+
+import studio.lunabee.microgallery.android.data.SettingsData
+
+interface SettingsRepository {
+    suspend fun getSettingsData() : SettingsData
+}

--- a/microGallery_KMP/local/build.gradle.kts
+++ b/microGallery_KMP/local/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
             implementation(libs.androidxSqliteBundled)
 
             implementation(projects.data)
+            implementation(projects.domain)
             implementation(projects.repository)
         }
     }

--- a/microGallery_KMP/local/schemas/studio.lunabee.amicrogallery.android.local.RoomAppDatabase/3.json
+++ b/microGallery_KMP/local/schemas/studio.lunabee.amicrogallery.android.local.RoomAppDatabase/3.json
@@ -1,0 +1,87 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "3e4aba4ce2b4d1d1fc1d277d9b945a96",
+    "entities": [
+      {
+        "tableName": "PhotosTable",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `fullResPath` TEXT, `lowResPath` TEXT, `year` TEXT, `month` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullResPath",
+            "columnName": "fullResPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lowResPath",
+            "columnName": "lowResPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "SettingsTable",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `ipvsix` TEXT NOT NULL, `ipvfour` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ipv6",
+            "columnName": "ipvsix",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ipv4",
+            "columnName": "ipvfour",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3e4aba4ce2b4d1d1fc1d277d9b945a96')"
+    ]
+  }
+}

--- a/microGallery_KMP/local/schemas/studio.lunabee.amicrogallery.android.local.RoomAppDatabase/3.json
+++ b/microGallery_KMP/local/schemas/studio.lunabee.amicrogallery.android.local.RoomAppDatabase/3.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 3,
-    "identityHash": "3e4aba4ce2b4d1d1fc1d277d9b945a96",
+    "identityHash": "0d3901b52a976026d48698243301261a",
     "entities": [
       {
         "tableName": "PhotosTable",
@@ -50,7 +50,7 @@
       },
       {
         "tableName": "SettingsTable",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `ipvsix` TEXT NOT NULL, `ipvfour` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `ipvsix` TEXT NOT NULL, `ipvfour` TEXT NOT NULL, `useIpvSix` INTEGER NOT NULL, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -69,6 +69,12 @@
             "columnName": "ipvfour",
             "affinity": "TEXT",
             "notNull": true
+          },
+          {
+            "fieldPath": "useIpv6",
+            "columnName": "useIpvSix",
+            "affinity": "INTEGER",
+            "notNull": true
           }
         ],
         "primaryKey": {
@@ -81,7 +87,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3e4aba4ce2b4d1d1fc1d277d9b945a96')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '0d3901b52a976026d48698243301261a')"
     ]
   }
 }

--- a/microGallery_KMP/local/schemas/studio.lunabee.amicrogallery.android.local.RoomAppDatabase/4.json
+++ b/microGallery_KMP/local/schemas/studio.lunabee.amicrogallery.android.local.RoomAppDatabase/4.json
@@ -1,8 +1,8 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 1,
-    "identityHash": "42c7e39b5167f137b33fc819ca4d091a",
+    "version": 4,
+    "identityHash": "0d3901b52a976026d48698243301261a",
     "entities": [
       {
         "tableName": "PhotosTable",
@@ -50,7 +50,7 @@
       },
       {
         "tableName": "SettingsTable",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `ipvsix` TEXT NOT NULL, `ipvfour` TEXT NOT NULL, `viewInHD` INTEGER NOT NULL, `useIpvSix` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `ipvsix` TEXT NOT NULL, `ipvfour` TEXT NOT NULL, `useIpvSix` INTEGER NOT NULL, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -71,12 +71,6 @@
             "notNull": true
           },
           {
-            "fieldPath": "viewInHD",
-            "columnName": "viewInHD",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
             "fieldPath": "useIpv6",
             "columnName": "useIpvSix",
             "affinity": "INTEGER",
@@ -93,7 +87,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '42c7e39b5167f137b33fc819ca4d091a')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '0d3901b52a976026d48698243301261a')"
     ]
   }
 }

--- a/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/RoomAppDatabase.kt
+++ b/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/RoomAppDatabase.kt
@@ -8,18 +8,23 @@ import androidx.sqlite.SQLiteConnection
 import androidx.sqlite.SQLiteDriver
 import androidx.sqlite.execSQL
 import studio.lunabee.amicrogallery.android.local.dao.PictureDao
+import studio.lunabee.amicrogallery.android.local.dao.SettingsDao
 import studio.lunabee.amicrogallery.android.local.entity.PictureEntity
+import studio.lunabee.amicrogallery.android.local.entity.SettingsEntity
+import studio.lunabee.amicrogallery.android.local.entity.SettingsTable
 import kotlin.coroutines.CoroutineContext
 
 @Database(
     entities = [
         PictureEntity::class,
+        SettingsEntity::class
     ],
-    version = 2,
+    version = 3,
 )
 @ConstructedBy(AppDatabaseConstructor::class)
 abstract class RoomAppDatabase : RoomDatabase() {
-    abstract fun pictureDao(): PictureDao
+    abstract fun pictureDao() : PictureDao
+    abstract fun settingsDao() : SettingsDao
 }
 
 expect class RoomPlatformBuilder {
@@ -47,15 +52,24 @@ fun buildRoomDatabase(
         .builder()
         .addCallback(
             object : RoomDatabase.Callback() {
+
                 override fun onCreate(connection: SQLiteConnection) {
                     super.onCreate(connection)
+                    val settingsEntity = SettingsEntity()
+
                     connection.execSQL("DELETE FROM PhotosTable")
+                    connection.execSQL(
+                        "INSERT INTO $SettingsTable (ipvfour, ipvsix)" +
+                        "VALUES ('${settingsEntity.ipv4}', '${settingsEntity.ipv6}')"
+                    )
+                    println("inserted well") // TODO : this is never print
+
                 }
             },
         )
-        // TODO here goes future migrations.
         .fallbackToDestructiveMigration(true)
         .setDriver(builder.getDriver())
         .setQueryCoroutineContext(context = context)
         .build()
 }
+

--- a/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/RoomAppDatabase.kt
+++ b/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/RoomAppDatabase.kt
@@ -17,14 +17,14 @@ import kotlin.coroutines.CoroutineContext
 @Database(
     entities = [
         PictureEntity::class,
-        SettingsEntity::class
+        SettingsEntity::class,
     ],
-    version = 3,
+    version = 1,
 )
 @ConstructedBy(AppDatabaseConstructor::class)
 abstract class RoomAppDatabase : RoomDatabase() {
-    abstract fun pictureDao() : PictureDao
-    abstract fun settingsDao() : SettingsDao
+    abstract fun pictureDao(): PictureDao
+    abstract fun settingsDao(): SettingsDao
 }
 
 expect class RoomPlatformBuilder {
@@ -56,14 +56,12 @@ fun buildRoomDatabase(
                 override fun onCreate(connection: SQLiteConnection) {
                     super.onCreate(connection)
                     val settingsEntity = SettingsEntity()
-
-                    connection.execSQL("DELETE FROM PhotosTable")
+                    // this is executed only when the app is first launched after install
                     connection.execSQL(
-                        "INSERT INTO $SettingsTable (ipvfour, ipvsix)" +
-                        "VALUES ('${settingsEntity.ipv4}', '${settingsEntity.ipv6}')"
+                        "INSERT INTO $SettingsTable (ipvfour, ipvsix, useIpvSix, viewInHD)" +
+                            "VALUES ('${settingsEntity.ipv4}', '${settingsEntity.ipv6}',"
+                            + "'${settingsEntity.useIpv6}', ${settingsEntity.viewInHD})",
                     )
-                    println("inserted well") // TODO : this is never print
-
                 }
             },
         )
@@ -72,4 +70,3 @@ fun buildRoomDatabase(
         .setQueryCoroutineContext(context = context)
         .build()
 }
-

--- a/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/dao/SettingsDao.kt
+++ b/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/dao/SettingsDao.kt
@@ -1,0 +1,19 @@
+package studio.lunabee.amicrogallery.android.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import studio.lunabee.amicrogallery.android.local.entity.SettingsEntity
+import studio.lunabee.amicrogallery.android.local.entity.SettingsTable
+import studio.lunabee.microgallery.android.data.SettingsData
+
+@Dao
+interface SettingsDao {
+    @Query("SELECT * FROM $SettingsTable")
+    suspend fun getSettings() : SettingsEntity
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun storeSettings(settingsEntity: SettingsEntity)
+
+}

--- a/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/dao/SettingsDao.kt
+++ b/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/dao/SettingsDao.kt
@@ -6,14 +6,12 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import studio.lunabee.amicrogallery.android.local.entity.SettingsEntity
 import studio.lunabee.amicrogallery.android.local.entity.SettingsTable
-import studio.lunabee.microgallery.android.data.SettingsData
 
 @Dao
 interface SettingsDao {
     @Query("SELECT * FROM $SettingsTable")
-    suspend fun getSettings() : SettingsEntity
+    suspend fun getSettings(): SettingsEntity
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun storeSettings(settingsEntity: SettingsEntity)
-
 }

--- a/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/datasource/SettingsLocalDatasource.kt
+++ b/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/datasource/SettingsLocalDatasource.kt
@@ -1,0 +1,17 @@
+package studio.lunabee.amicrogallery.android.local.datasource
+
+import studio.lunabee.amicrogallery.android.local.dao.SettingsDao
+import studio.lunabee.amicrogallery.android.local.entity.SettingsEntity
+import studio.lunabee.amicrogallery.settings.SettingsLocal
+import studio.lunabee.microgallery.android.data.SettingsData
+
+class SettingsLocalDatasource(
+    private val settingsDao : SettingsDao
+) : SettingsLocal {
+    override suspend fun getSettings() : SettingsData{
+        return settingsDao.getSettings().toSettingsData()
+    }
+    override suspend fun storeSettings(settingsData: SettingsData){
+        settingsDao.storeSettings(SettingsEntity.fromSettingsData(settingsData))
+    }
+}

--- a/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/datasource/SettingsLocalDatasource.kt
+++ b/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/datasource/SettingsLocalDatasource.kt
@@ -4,14 +4,22 @@ import studio.lunabee.amicrogallery.android.local.dao.SettingsDao
 import studio.lunabee.amicrogallery.android.local.entity.SettingsEntity
 import studio.lunabee.amicrogallery.settings.SettingsLocal
 import studio.lunabee.microgallery.android.data.SettingsData
+import studio.lunabee.microgallery.android.domain.loading.LoadingRepository
 
 class SettingsLocalDatasource(
-    private val settingsDao : SettingsDao
+    private val settingsDao: SettingsDao,
+    private val loadingRepository: LoadingRepository,
 ) : SettingsLocal {
-    override suspend fun getSettings() : SettingsData{
+
+    override suspend fun getSettings(): SettingsData {
         return settingsDao.getSettings().toSettingsData()
     }
-    override suspend fun storeSettings(settingsData: SettingsData){
+
+    override suspend fun storeSettings(settingsData: SettingsData) {
         settingsDao.storeSettings(SettingsEntity.fromSettingsData(settingsData))
+    }
+
+    override suspend fun clearDB() {
+        loadingRepository.fetchRootNode()
     }
 }

--- a/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/entity/SettingsEntity.kt
+++ b/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/entity/SettingsEntity.kt
@@ -8,25 +8,31 @@ import studio.lunabee.microgallery.android.data.SettingsData
 const val SettingsTable = "SettingsTable"
 
 @Entity(
-    tableName = SettingsTable
+    tableName = SettingsTable,
 )
-data class SettingsEntity (
-    @PrimaryKey @ColumnInfo(name="id") val id : Long = 4871L,
-    @ColumnInfo(name="ipvsix") val ipv6 : String = "2a01:cb1c:82c7:5e00:9f05:da30:3fcf:58ac",
-    @ColumnInfo(name="ipvfour") val ipv4  : String = "92.150.239.130",
-){
-    fun toSettingsData(): SettingsData{
+data class SettingsEntity(
+    @PrimaryKey @ColumnInfo(name = "id") val id: Long = 4871L,
+    @ColumnInfo(name = "ipvsix") val ipv6: String = "2a01:cb1c:82c7:5e00:9f05:da30:3fcf:58ac",
+    @ColumnInfo(name = "ipvfour") val ipv4: String = "92.150.239.130",
+    @ColumnInfo(name = "viewInHD") val viewInHD: Boolean = true,
+    @ColumnInfo(name = "useIpvSix") val useIpv6: Boolean = false,
+) {
+    fun toSettingsData(): SettingsData {
         return SettingsData(
             ipv4 = ipv4,
-            ipv6 = ipv6
+            ipv6 = ipv6,
+            useIpv6 = useIpv6,
+            viewInHD = viewInHD,
         )
     }
 
     companion object {
-        fun fromSettingsData(settingsData: SettingsData) : SettingsEntity {
+        fun fromSettingsData(settingsData: SettingsData): SettingsEntity {
             return SettingsEntity(
                 ipv4 = settingsData.ipv4,
-                ipv6 = settingsData.ipv6
+                ipv6 = settingsData.ipv6,
+                useIpv6 = settingsData.useIpv6,
+                viewInHD = settingsData.viewInHD,
             )
         }
     }

--- a/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/entity/SettingsEntity.kt
+++ b/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/entity/SettingsEntity.kt
@@ -1,0 +1,33 @@
+package studio.lunabee.amicrogallery.android.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import studio.lunabee.microgallery.android.data.SettingsData
+
+const val SettingsTable = "SettingsTable"
+
+@Entity(
+    tableName = SettingsTable
+)
+data class SettingsEntity (
+    @PrimaryKey @ColumnInfo(name="id") val id : Long = 4871L,
+    @ColumnInfo(name="ipvsix") val ipv6 : String = "2a01:cb1c:82c7:5e00:9f05:da30:3fcf:58ac",
+    @ColumnInfo(name="ipvfour") val ipv4  : String = "92.150.239.130",
+){
+    fun toSettingsData(): SettingsData{
+        return SettingsData(
+            ipv4 = ipv4,
+            ipv6 = ipv6
+        )
+    }
+
+    companion object {
+        fun fromSettingsData(settingsData: SettingsData) : SettingsEntity {
+            return SettingsEntity(
+                ipv4 = settingsData.ipv4,
+                ipv6 = settingsData.ipv6
+            )
+        }
+    }
+}

--- a/microGallery_KMP/remote/src/commonMain/kotlin/studio/lunabee/microgallery/android/remote/datasource/RemoteStatusDatasourceImpl.kt
+++ b/microGallery_KMP/remote/src/commonMain/kotlin/studio/lunabee/microgallery/android/remote/datasource/RemoteStatusDatasourceImpl.kt
@@ -1,0 +1,14 @@
+package studio.lunabee.microgallery.android.remote.datasource
+
+import studio.lunabee.microgallery.android.data.RemoteStatus
+import studio.lunabee.microgallery.android.remote.service.RootService
+import studio.lunabee.microgallery.android.repository.datasource.remote.RemoteStatusDatasource
+
+class RemoteStatusDatasourceImpl(
+    private val rootService: RootService,
+) : RemoteStatusDatasource {
+
+    override suspend fun fetchStatus(): RemoteStatus {
+        return rootService.fetchStatus().toRemoteStatus()
+    }
+}

--- a/microGallery_KMP/remote/src/commonMain/kotlin/studio/lunabee/microgallery/android/remote/model/BashRemoteStatus.kt
+++ b/microGallery_KMP/remote/src/commonMain/kotlin/studio/lunabee/microgallery/android/remote/model/BashRemoteStatus.kt
@@ -1,0 +1,21 @@
+package studio.lunabee.microgallery.android.remote.model
+
+import kotlinx.serialization.Serializable
+import studio.lunabee.microgallery.android.data.RemoteStatus
+
+@Serializable
+data class BashRemoteStatus(
+    val temperature: Int,
+    val isplugged: Boolean,
+    val quantityhr: Int,
+    val quantitylr: Int,
+) {
+    fun toRemoteStatus(): RemoteStatus {
+        return RemoteStatus(
+            isPlugged = isplugged,
+            temperature = temperature,
+            quantityHighRes = quantityhr,
+            quantityLowRes = quantitylr,
+        )
+    }
+}

--- a/microGallery_KMP/remote/src/commonMain/kotlin/studio/lunabee/microgallery/android/remote/service/RootService.kt
+++ b/microGallery_KMP/remote/src/commonMain/kotlin/studio/lunabee/microgallery/android/remote/service/RootService.kt
@@ -3,6 +3,7 @@ package studio.lunabee.microgallery.android.remote.service
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import studio.lunabee.microgallery.android.remote.CoreHttpClient
+import studio.lunabee.microgallery.android.remote.model.BashRemoteStatus
 import studio.lunabee.microgallery.android.remote.model.RemoteMicroElement
 
 class RootService(
@@ -10,5 +11,9 @@ class RootService(
 ) {
     suspend fun fetchRootList(): List<RemoteMicroElement> {
         return coreHttpClient.httpClient.get("/commande/treeJSON").body()
+    }
+
+    suspend fun fetchStatus(): BashRemoteStatus {
+        return coreHttpClient.httpClient.get("/commande/status").body()
     }
 }

--- a/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/amicrogallery/settings/SettingsLocal.kt
+++ b/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/amicrogallery/settings/SettingsLocal.kt
@@ -1,0 +1,8 @@
+package studio.lunabee.amicrogallery.settings
+
+import studio.lunabee.microgallery.android.data.SettingsData
+
+interface SettingsLocal {
+    suspend fun getSettings() : SettingsData
+    suspend fun storeSettings(settingsData: SettingsData)
+}

--- a/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/amicrogallery/settings/SettingsLocal.kt
+++ b/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/amicrogallery/settings/SettingsLocal.kt
@@ -3,6 +3,8 @@ package studio.lunabee.amicrogallery.settings
 import studio.lunabee.microgallery.android.data.SettingsData
 
 interface SettingsLocal {
-    suspend fun getSettings() : SettingsData
+    suspend fun getSettings(): SettingsData
     suspend fun storeSettings(settingsData: SettingsData)
+
+    suspend fun clearDB()
 }

--- a/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/microgallery/android/repository/datasource/remote/RemoteStatusDatasource.kt
+++ b/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/microgallery/android/repository/datasource/remote/RemoteStatusDatasource.kt
@@ -1,0 +1,7 @@
+package studio.lunabee.microgallery.android.repository.datasource.remote
+
+import studio.lunabee.microgallery.android.data.RemoteStatus
+
+interface RemoteStatusDatasource {
+    suspend fun fetchStatus(): RemoteStatus
+}

--- a/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/microgallery/android/repository/impl/SettingsRepositoryImpl.kt
+++ b/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/microgallery/android/repository/impl/SettingsRepositoryImpl.kt
@@ -1,13 +1,31 @@
 package studio.lunabee.microgallery.android.repository.impl
 
 import studio.lunabee.amicrogallery.settings.SettingsLocal
+import studio.lunabee.microgallery.android.data.RemoteStatus
 import studio.lunabee.microgallery.android.data.SettingsData
 import studio.lunabee.microgallery.android.domain.settings.SettingsRepository
+import studio.lunabee.microgallery.android.repository.datasource.remote.RemoteStatusDatasource
 
-class SettingsRepositoryImpl(private val settingsLocal: SettingsLocal): SettingsRepository
-{
-    private val settingsData : SettingsData? = null
+class SettingsRepositoryImpl(
+    private val settingsLocal: SettingsLocal,
+    private val remoteStatusDatasource: RemoteStatusDatasource,
+) : SettingsRepository {
+    private var settingsData: SettingsData? = null
+
     override suspend fun getSettingsData(): SettingsData {
-        return settingsLocal.getSettings()
+        return settingsData ?: settingsLocal.getSettings().also { settingsData = it }
+    }
+
+    override suspend fun clearDB() {
+        settingsLocal.clearDB()
+    }
+
+    override suspend fun getStatus(): RemoteStatus {
+        return remoteStatusDatasource.fetchStatus()
+    }
+
+    override suspend fun setSettingsData(settingsUiData: SettingsData) {
+        settingsData = settingsUiData
+        settingsLocal.storeSettings(settingsUiData)
     }
 }

--- a/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/microgallery/android/repository/impl/SettingsRepositoryImpl.kt
+++ b/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/microgallery/android/repository/impl/SettingsRepositoryImpl.kt
@@ -1,0 +1,13 @@
+package studio.lunabee.microgallery.android.repository.impl
+
+import studio.lunabee.amicrogallery.settings.SettingsLocal
+import studio.lunabee.microgallery.android.data.SettingsData
+import studio.lunabee.microgallery.android.domain.settings.SettingsRepository
+
+class SettingsRepositoryImpl(private val settingsLocal: SettingsLocal): SettingsRepository
+{
+    private val settingsData : SettingsData? = null
+    override suspend fun getSettingsData(): SettingsData {
+        return settingsLocal.getSettings()
+    }
+}

--- a/microGallery_KMP/shared/src/androidMain/kotlin/studio/lunabee/amicrogallery/android/shared/RemoteModule.kt
+++ b/microGallery_KMP/shared/src/androidMain/kotlin/studio/lunabee/amicrogallery/android/shared/RemoteModule.kt
@@ -3,11 +3,14 @@ package studio.lunabee.amicrogallery.android.shared
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
+import studio.lunabee.microgallery.android.remote.datasource.RemoteStatusDatasourceImpl
 import studio.lunabee.microgallery.android.remote.datasource.TreeRemoteDatasourceImpl
 import studio.lunabee.microgallery.android.remote.service.RootService
+import studio.lunabee.microgallery.android.repository.datasource.remote.RemoteStatusDatasource
 import studio.lunabee.microgallery.android.repository.datasource.remote.TreeRemoteDatasource
 
 val remoteDatasourceModule = module {
     singleOf(::RootService)
     singleOf(::TreeRemoteDatasourceImpl) bind TreeRemoteDatasource::class
+    singleOf(::RemoteStatusDatasourceImpl) bind RemoteStatusDatasource::class
 }

--- a/microGallery_KMP/shared/src/androidMain/kotlin/studio/lunabee/amicrogallery/android/shared/RepositoryModule.kt
+++ b/microGallery_KMP/shared/src/androidMain/kotlin/studio/lunabee/amicrogallery/android/shared/RepositoryModule.kt
@@ -7,11 +7,13 @@ import studio.lunabee.microgallery.android.domain.calendar.CalendarRepository
 import studio.lunabee.microgallery.android.domain.lastMonth.LastMonthRepository
 import studio.lunabee.microgallery.android.domain.loading.LoadingRepository
 import studio.lunabee.microgallery.android.domain.photoviewer.PhotoViewerRepository
+import studio.lunabee.microgallery.android.domain.settings.SettingsRepository
 import studio.lunabee.microgallery.android.domain.untimed.UntimedRepository
 import studio.lunabee.microgallery.android.repository.impl.CalendarRepositoryImpl
 import studio.lunabee.microgallery.android.repository.impl.LastMonthRepositoryImpl
 import studio.lunabee.microgallery.android.repository.impl.LoadingRepositoryImpl
 import studio.lunabee.microgallery.android.repository.impl.PhotoViewerRepositoryImpl
+import studio.lunabee.microgallery.android.repository.impl.SettingsRepositoryImpl
 import studio.lunabee.microgallery.android.repository.impl.UntimedRepositoryImpl
 
 val repositoryModule = module {
@@ -20,4 +22,5 @@ val repositoryModule = module {
     singleOf(::UntimedRepositoryImpl) bind UntimedRepository::class
     singleOf(::LastMonthRepositoryImpl) bind LastMonthRepository::class
     singleOf(::PhotoViewerRepositoryImpl) bind PhotoViewerRepository::class
+    singleOf(::SettingsRepositoryImpl) bind SettingsRepository::class
 }

--- a/microGallery_KMP/shared/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/shared/LocalModule.kt
+++ b/microGallery_KMP/shared/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/shared/LocalModule.kt
@@ -32,5 +32,4 @@ internal val LocalModule: Module = module {
     // Dao
     single<PictureDao> { get<RoomAppDatabase>().pictureDao() }
     single<SettingsDao> { get<RoomAppDatabase>().settingsDao() }
-
 }

--- a/microGallery_KMP/shared/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/shared/LocalModule.kt
+++ b/microGallery_KMP/shared/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/shared/LocalModule.kt
@@ -9,8 +9,11 @@ import org.koin.dsl.module
 import studio.lunabee.amicrogallery.android.local.RoomAppDatabase
 import studio.lunabee.amicrogallery.android.local.buildRoomDatabase
 import studio.lunabee.amicrogallery.android.local.dao.PictureDao
+import studio.lunabee.amicrogallery.android.local.dao.SettingsDao
 import studio.lunabee.amicrogallery.android.local.datasource.PictureLocalDatasource
+import studio.lunabee.amicrogallery.android.local.datasource.SettingsLocalDatasource
 import studio.lunabee.amicrogallery.picture.PictureLocal
+import studio.lunabee.amicrogallery.settings.SettingsLocal
 
 internal val LocalModule: Module = module {
 
@@ -24,7 +27,10 @@ internal val LocalModule: Module = module {
 
     // Bind repository expectations
     singleOf(::PictureLocalDatasource) bind PictureLocal::class
+    singleOf(::SettingsLocalDatasource) bind SettingsLocal::class
 
     // Dao
     single<PictureDao> { get<RoomAppDatabase>().pictureDao() }
+    single<SettingsDao> { get<RoomAppDatabase>().settingsDao() }
+
 }


### PR DESCRIPTION
## 📜 Description

Give motion to settings screen, and storing user preferences, but for the moment those preferences are not used

## 💡 Motivation and Context

In order to being able to change options on the fly, the user can modify and check status of his server very easly

## 💚 How did you test it?

pixel 6A with server up and running

## 📝 Checklist

* [x] 📖 I reviewed the submitted code
* [x] 🛀 I launched `./gradlew detekt`
* [ ] 📡 I checked on iOS how it was done and fill their ticket with any specific information if it's not done yet
* [ ] 🦮 I verified the accessibility (if it makes sense)
* [ ] 🏭 I implemented Unit Tests (if it makes sense)

## 🔮 Next steps

Actually use users preferences instead of just storing them

## 📸 Screenshots / GIFs
