### PR TITLE
feature/fetch-once

### DIFF
--- a/.idea/deviceManager.xml
+++ b/.idea/deviceManager.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DeviceTable">
+    <option name="columnSorters">
+      <list>
+        <ColumnSorterState>
+          <option name="column" value="Name" />
+          <option name="order" value="ASCENDING" />
+        </ColumnSorterState>
+      </list>
+    </option>
+  </component>
+</project>

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/MainActivity.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/MainActivity.kt
@@ -5,8 +5,6 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.navigation.compose.rememberNavController
-import kotlinx.coroutines.coroutineScope
-import org.koin.core.option.viewModelScopeFactory
 import studio.lunabee.amicrogallery.android.core.ui.theme.MicroGalleryTheme
 import studio.lunabee.amicrogallery.android.core.ui.theme.coreEnableEdgeToEdge
 

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/MainActivity.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/MainActivity.kt
@@ -5,6 +5,8 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.coroutineScope
+import org.koin.core.option.viewModelScopeFactory
 import studio.lunabee.amicrogallery.android.core.ui.theme.MicroGalleryTheme
 import studio.lunabee.amicrogallery.android.core.ui.theme.coreEnableEdgeToEdge
 

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/MainNavGraph.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/MainNavGraph.kt
@@ -7,8 +7,10 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import studio.lunabee.amicrogallery.dashboard.DashboardDestination
+import studio.lunabee.amicrogallery.dashboard.DashboardNavScope
 import studio.lunabee.amicrogallery.loading.LoadingDestination
 import studio.lunabee.amicrogallery.loading.LoadingNavScope
+import studio.lunabee.amicrogallery.loading.LoadingScreen
 import kotlin.reflect.KClass
 
 @OptIn(ExperimentalSharedTransitionApi::class)
@@ -25,7 +27,7 @@ fun MainNavGraph(
         ) {
             DashboardDestination.composable(
                 navGraphBuilder = this,
-                navController = navController,
+                navController = navController
             )
 
             LoadingDestination.composable(

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/MainNavGraph.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/MainNavGraph.kt
@@ -7,10 +7,8 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import studio.lunabee.amicrogallery.dashboard.DashboardDestination
-import studio.lunabee.amicrogallery.dashboard.DashboardNavScope
 import studio.lunabee.amicrogallery.loading.LoadingDestination
 import studio.lunabee.amicrogallery.loading.LoadingNavScope
-import studio.lunabee.amicrogallery.loading.LoadingScreen
 import kotlin.reflect.KClass
 
 @OptIn(ExperimentalSharedTransitionApi::class)
@@ -27,7 +25,7 @@ fun MainNavGraph(
         ) {
             DashboardDestination.composable(
                 navGraphBuilder = this,
-                navController = navController
+                navController = navController,
             )
 
             LoadingDestination.composable(

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/MicroGalleryApplication.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/MicroGalleryApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.logger.Level
+import org.koin.core.option.viewModelScopeFactory
 import studio.lunabee.amicrogallery.android.shared.KoinHelper
 import studio.lunabee.amicrogallery.android.shared.remoteDatasourceModule
 import studio.lunabee.amicrogallery.android.shared.repositoryModule
@@ -16,9 +17,7 @@ class MicroGalleryApplication : Application() {
 
         KoinHelper.init {
             androidLogger(level = Level.INFO)
-
             androidContext(this@MicroGalleryApplication)
-
             modules(presentersModule)
             modules(repositoryModule)
             modules(remoteDatasourceModule)

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/MicroGalleryApplication.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/MicroGalleryApplication.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.logger.Level
-import org.koin.core.option.viewModelScopeFactory
 import studio.lunabee.amicrogallery.android.shared.KoinHelper
 import studio.lunabee.amicrogallery.android.shared.remoteDatasourceModule
 import studio.lunabee.amicrogallery.android.shared.repositoryModule

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/dashboard/DashboardNavScope.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/dashboard/DashboardNavScope.kt
@@ -1,0 +1,5 @@
+package studio.lunabee.amicrogallery.dashboard
+
+interface DashboardNavScope{
+    val navigateToLoading : () -> Unit
+}

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/dashboard/DashboardNavScope.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/dashboard/DashboardNavScope.kt
@@ -1,5 +1,5 @@
 package studio.lunabee.amicrogallery.dashboard
 
-interface DashboardNavScope{
-    val navigateToLoading : () -> Unit
+interface DashboardNavScope {
+    val navigateToLoading: () -> Unit
 }

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/dashboard/DashboardRoute.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/dashboard/DashboardRoute.kt
@@ -20,6 +20,8 @@ import studio.lunabee.amicrogallery.calendar.CalendarDestination
 import studio.lunabee.amicrogallery.calendar.CalendarNavScope
 import studio.lunabee.amicrogallery.lastmonth.LastMonthDestination
 import studio.lunabee.amicrogallery.lastmonth.LastMonthNavScope
+import studio.lunabee.amicrogallery.loading.LoadingDestination
+import studio.lunabee.amicrogallery.loading.LoadingNavScope
 import studio.lunabee.amicrogallery.photoviewer.PhotoViewerDestination
 import studio.lunabee.amicrogallery.photoviewer.PhotoViewerNavScope
 import studio.lunabee.amicrogallery.settings.SettingsDestination
@@ -31,7 +33,7 @@ import kotlin.reflect.KClass
 @Composable
 fun DashboardRoute(navController: NavHostController) {
     DashboardScreen(
-        navHostController = navController,
+        navController = navController,
         startDestination = CalendarDestination::class,
     )
 }
@@ -41,7 +43,7 @@ val LocalBottomBarHeight = compositionLocalOf<Int> { error("No value found !") }
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun DashboardScreen(
-    navHostController: NavHostController,
+    navController: NavHostController,
     startDestination: KClass<*>,
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
@@ -50,20 +52,19 @@ fun DashboardScreen(
         CompositionLocalProvider(LocalBottomBarHeight provides barHeight) {
             SharedTransitionLayout {
                 NavHost(
-                    navController = navHostController,
+                    navController = navController,
                     startDestination = startDestination,
                 ) {
                     PhotoViewerDestination().composable(
                         navGraphBuilder = this,
                         navScope = object : PhotoViewerNavScope {},
                     )
-
                     CalendarDestination.composable(
                         navGraphBuilder = this,
                         navScope = object : CalendarNavScope {
-                            override val navigateToSettings: () -> Unit = { navHostController.navigate(SettingsDestination) }
+                            override val navigateToSettings: () -> Unit = { navController.navigate(SettingsDestination) }
                             override val navigateToPhotoViewer: (Long) -> Unit = { photoId: Long ->
-                                navHostController.navigate(PhotoViewerDestination(photoId))
+                                navController.navigate(PhotoViewerDestination(photoId))
                             }
                         },
                     )
@@ -71,7 +72,7 @@ fun DashboardScreen(
                         navGraphBuilder = this,
                         navScope = object : UntimedNavScope {
                             override val navigateToPhotoViewer: (Long) -> Unit = { photoId: Long ->
-                                navHostController.navigate(PhotoViewerDestination(photoId))
+                                navController.navigate(PhotoViewerDestination(photoId))
                             }
                         },
                     )
@@ -79,26 +80,38 @@ fun DashboardScreen(
                         navGraphBuilder = this,
                         navScope = object : LastMonthNavScope {
                             override val navigateToPhotoViewer: (Long) -> Unit = { photoId: Long ->
-                                navHostController.navigate(PhotoViewerDestination(photoId))
+                                navController.navigate(PhotoViewerDestination(photoId))
                             }
                         },
+                    )
+                    LoadingDestination.composable(
+                        navGraphBuilder = this,
+                        navScope = object : LoadingNavScope{
+                            override val navigateToDashboard = {
+                                navController.navigate(CalendarDestination)
+                            }
+                        }
                     )
                     SettingsDestination.composable(
                         navGraphBuilder = this,
                         navScope = object : SettingsNavScope {
                             override fun jumpBack() {
-                                navHostController.navigateUp()
+                                navController.navigateUp()
                             }
 
                             override fun jumpUntimed() {
-                                navHostController.navigate(UntimedDestination)
+                                navController.navigate(UntimedDestination)
+                            }
+
+                            override fun jumpDashBoard() {
+                                navController.navigate(LoadingDestination)
                             }
                         },
                     )
                 }
             }
             MicroGalleryBottomBar(
-                navController = navHostController,
+                navController = navController,
                 modifier = Modifier
                     .align(alignment = Alignment.BottomCenter)
                     .onGloballyPositioned { coordinates ->

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/dashboard/DashboardRoute.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/dashboard/DashboardRoute.kt
@@ -86,11 +86,11 @@ fun DashboardScreen(
                     )
                     LoadingDestination.composable(
                         navGraphBuilder = this,
-                        navScope = object : LoadingNavScope{
+                        navScope = object : LoadingNavScope {
                             override val navigateToDashboard = {
                                 navController.navigate(CalendarDestination)
                             }
-                        }
+                        },
                     )
                     SettingsDestination.composable(
                         navGraphBuilder = this,

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/loading/LoadingAction.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/loading/LoadingAction.kt
@@ -1,8 +1,14 @@
 package studio.lunabee.amicrogallery.loading
 
+import studio.lunabee.microgallery.android.data.MYear
+
 sealed interface LoadingAction {
     sealed interface ErrorAction : LoadingAction
     sealed interface FetchingAction : LoadingAction
     object FoundAll : FetchingAction
+    data class FoundYear(
+        val years: List<MYear>,
+    ) : FetchingAction
+
     data class Error(val errorMessage: String?) : FetchingAction
 }

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/loading/LoadingPresenter.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/loading/LoadingPresenter.kt
@@ -5,32 +5,39 @@ import FetchingReducer
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import studio.lunabee.compose.presenter.LBPresenter
 import studio.lunabee.compose.presenter.LBSimpleReducer
+import studio.lunabee.microgallery.android.domain.loading.usecase.ListYearsFlowUseCase
 import studio.lunabee.microgallery.android.domain.loading.usecase.PhotoDbIsEmptyUseCase
 import studio.lunabee.microgallery.android.domain.loading.usecase.UpdateTreeUseCase
 
 class LoadingPresenter(
     val updateTreeUseCase: UpdateTreeUseCase,
-    val photoDbIsEmptyUseCase: PhotoDbIsEmptyUseCase
+    val photoDbIsEmptyUseCase: PhotoDbIsEmptyUseCase,
+    val yearsFlowUseCase: ListYearsFlowUseCase,
 ) : LBPresenter<LoadingUiState, LoadingNavScope, LoadingAction>() {
+    val yearsFlow = yearsFlowUseCase().map { LoadingAction.FoundYear(it) }
 
     init {
         viewModelScope.launch {
-            if(photoDbIsEmptyUseCase())
+            if (photoDbIsEmptyUseCase()) {
                 updateTreeUseCase()
+            }
             emitUserAction(LoadingAction.FoundAll)
         }
     }
 
-    override val flows: List<Flow<LoadingAction>> = listOf()
+    override val flows: List<Flow<LoadingAction>> = listOf(
+        yearsFlow,
+    )
 
-    override fun getInitialState(): LoadingUiState = LoadingUiState.Fetching
+    override fun getInitialState(): LoadingUiState = LoadingUiState.Fetching(emptyList())
 
     override fun getReducerByState(actualState: LoadingUiState): LBSimpleReducer<LoadingUiState, LoadingNavScope, LoadingAction> {
         return when (actualState) {
-            LoadingUiState.Fetching -> FetchingReducer(
+            is LoadingUiState.Fetching -> FetchingReducer(
                 coroutineScope = viewModelScope,
                 emitUserAction = ::emitUserAction,
             )

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/loading/LoadingPresenter.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/loading/LoadingPresenter.kt
@@ -8,15 +8,18 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import studio.lunabee.compose.presenter.LBPresenter
 import studio.lunabee.compose.presenter.LBSimpleReducer
+import studio.lunabee.microgallery.android.domain.loading.usecase.PhotoDbIsEmptyUseCase
 import studio.lunabee.microgallery.android.domain.loading.usecase.UpdateTreeUseCase
 
 class LoadingPresenter(
     val updateTreeUseCase: UpdateTreeUseCase,
+    val photoDbIsEmptyUseCase: PhotoDbIsEmptyUseCase
 ) : LBPresenter<LoadingUiState, LoadingNavScope, LoadingAction>() {
 
     init {
         viewModelScope.launch {
-            updateTreeUseCase()
+            if(photoDbIsEmptyUseCase())
+                updateTreeUseCase()
             emitUserAction(LoadingAction.FoundAll)
         }
     }

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/loading/LoadingScreen.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/loading/LoadingScreen.kt
@@ -22,12 +22,12 @@ import studio.lunabee.amicrogallery.app.R
 fun LoadingScreen(loadingUiState: LoadingUiState) {
     when (loadingUiState) {
         is LoadingUiState.Error -> ShowError(loadingUiState)
-        is LoadingUiState.Fetching -> WaitingForResponse()
+        is LoadingUiState.Fetching -> WaitingForResponse(loadingUiState)
     }
 }
 
 @Composable
-fun WaitingForResponse() {
+fun WaitingForResponse(uiState: LoadingUiState.Fetching) {
     Box(modifier = Modifier.fillMaxSize()) {
         Column(modifier = Modifier.align(Alignment.Center)) {
             Text(
@@ -42,7 +42,13 @@ fun WaitingForResponse() {
             LinearProgressIndicator(
                 color = colors.main,
                 trackColor = colors.second.copy(alpha = 0.5f),
+                modifier = Modifier.align(Alignment.CenterHorizontally),
             )
+            uiState.years.forEach {
+                Text(
+                    text = stringResource(R.string.year_found, it),
+                )
+            }
         }
     }
 }

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/loading/LoadingUiState.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/loading/LoadingUiState.kt
@@ -1,6 +1,7 @@
 package studio.lunabee.amicrogallery.loading
 
 import studio.lunabee.compose.presenter.PresenterUiState
+import studio.lunabee.microgallery.android.data.MYear
 
 sealed interface LoadingUiState : PresenterUiState {
 
@@ -9,5 +10,7 @@ sealed interface LoadingUiState : PresenterUiState {
         val reload: () -> Unit,
     ) : LoadingUiState
 
-    object Fetching : LoadingUiState
+    data class Fetching(
+        val years: List<MYear>,
+    ) : LoadingUiState
 }

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/loading/reducers/FetchingReducer.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/loading/reducers/FetchingReducer.kt
@@ -28,6 +28,8 @@ class FetchingReducer(
                 errorMessage = action.errorMessage,
                 reload = { },
             ).asResult()
+
+            is LoadingAction.FoundYear -> actualState.copy(years = action.years).asResult()
         }
     }
 

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsAction.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsAction.kt
@@ -15,6 +15,8 @@ sealed interface SettingsAction {
         val context: Context,
     ) : SettingsAction
 
+    object ResetSettings : SettingsAction
+
     data object ToggleIpv6 : SettingsAction
     data object ToggleViewInHD : SettingsAction
     data class SetIpv6(

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsAction.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsAction.kt
@@ -9,6 +9,7 @@ sealed interface SettingsAction {
 
     object JumpBack : SettingsAction
     object JumpUntimed : SettingsAction
+    object JumpDashBoard : SettingsAction
 
     data class Clear(
         val context: Context,

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsNavScope.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsNavScope.kt
@@ -3,4 +3,5 @@ package studio.lunabee.amicrogallery.settings
 interface SettingsNavScope {
     fun jumpBack(): Unit
     fun jumpUntimed(): Unit
+    fun jumpDashBoard(): Unit
 }

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsPresenter.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsPresenter.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.flow.map
 import studio.lunabee.compose.presenter.LBSinglePresenter
 import studio.lunabee.compose.presenter.LBSingleReducer
 import studio.lunabee.microgallery.android.data.SettingsData
-import studio.lunabee.microgallery.android.domain.settings.SettingsRepository
 import studio.lunabee.microgallery.android.domain.settings.usecase.EmptyPhotoDbUseCase
 import studio.lunabee.microgallery.android.domain.settings.usecase.ObserveSettingsUseCase
 import studio.lunabee.microgallery.android.domain.settings.usecase.ObserveStatusUseCase
@@ -17,7 +16,7 @@ class SettingsPresenter(
     val observeSettingsUseCase: ObserveSettingsUseCase,
     val observeStatusUseCase: ObserveStatusUseCase,
     val emptyPhotoDbUseCase: EmptyPhotoDbUseCase,
-    val setSettingsUseCase: SetSettingsUseCase
+    val setSettingsUseCase: SetSettingsUseCase,
 ) : LBSinglePresenter<SettingsUiState, SettingsNavScope, SettingsAction>() {
 
     val settingsData = observeSettingsUseCase().map {
@@ -50,6 +49,7 @@ class SettingsPresenter(
         toggleViewInHD = { emitUserAction(SettingsAction.ToggleViewInHD) },
         jumpUntimed = { emitUserAction(SettingsAction.JumpUntimed) },
         jumpDashBoard = { emitUserAction(SettingsAction.JumpDashBoard) },
+        resetData = { emitUserAction(SettingsAction.ResetSettings) },
     )
 
     override fun initReducer(): LBSingleReducer<SettingsUiState, SettingsNavScope, SettingsAction> {

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsPresenter.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsPresenter.kt
@@ -8,13 +8,16 @@ import studio.lunabee.compose.presenter.LBSinglePresenter
 import studio.lunabee.compose.presenter.LBSingleReducer
 import studio.lunabee.microgallery.android.data.SettingsData
 import studio.lunabee.microgallery.android.domain.settings.SettingsRepository
+import studio.lunabee.microgallery.android.domain.settings.usecase.EmptyPhotoDbUseCase
 import studio.lunabee.microgallery.android.domain.settings.usecase.ObserveSettingsUseCase
 import studio.lunabee.microgallery.android.domain.settings.usecase.ObserveStatusUseCase
+import studio.lunabee.microgallery.android.domain.settings.usecase.SetSettingsUseCase
 
 class SettingsPresenter(
-    val settingsRepository: SettingsRepository,
     val observeSettingsUseCase: ObserveSettingsUseCase,
     val observeStatusUseCase: ObserveStatusUseCase,
+    val emptyPhotoDbUseCase: EmptyPhotoDbUseCase,
+    val setSettingsUseCase: SetSettingsUseCase
 ) : LBSinglePresenter<SettingsUiState, SettingsNavScope, SettingsAction>() {
 
     val settingsData = observeSettingsUseCase().map {
@@ -46,13 +49,15 @@ class SettingsPresenter(
         setIpv6 = { emitUserAction(SettingsAction.SetIpv6(it)) },
         toggleViewInHD = { emitUserAction(SettingsAction.ToggleViewInHD) },
         jumpUntimed = { emitUserAction(SettingsAction.JumpUntimed) },
+        jumpDashBoard = { emitUserAction(SettingsAction.JumpDashBoard) },
     )
 
     override fun initReducer(): LBSingleReducer<SettingsUiState, SettingsNavScope, SettingsAction> {
         return SettingsReducer(
             coroutineScope = viewModelScope,
             emitUserAction = ::emitUserAction,
-            settingsRepository = settingsRepository,
+            emptyPhotoDbUseCase = emptyPhotoDbUseCase,
+            setSettingsUseCase = setSettingsUseCase,
         )
     }
 

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsReducer.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsReducer.kt
@@ -7,8 +7,6 @@ import studio.lunabee.compose.presenter.ReduceResult
 import studio.lunabee.compose.presenter.asResult
 import studio.lunabee.compose.presenter.withSideEffect
 import studio.lunabee.microgallery.android.data.SettingsData
-import studio.lunabee.microgallery.android.domain.loading.usecase.PhotoDbIsEmptyUseCase
-import studio.lunabee.microgallery.android.domain.settings.SettingsRepository
 import studio.lunabee.microgallery.android.domain.settings.usecase.EmptyPhotoDbUseCase
 import studio.lunabee.microgallery.android.domain.settings.usecase.SetSettingsUseCase
 
@@ -16,7 +14,7 @@ class SettingsReducer(
     override val coroutineScope: CoroutineScope,
     override val emitUserAction: (SettingsAction) -> Unit,
     val setSettingsUseCase: SetSettingsUseCase,
-    val emptyPhotoDbUseCase: EmptyPhotoDbUseCase
+    val emptyPhotoDbUseCase: EmptyPhotoDbUseCase,
 ) : LBSingleReducer<SettingsUiState, SettingsNavScope, SettingsAction>() {
 
     override suspend fun reduce(
@@ -31,12 +29,14 @@ class SettingsReducer(
                     jumpBack()
                 }
             }
+
             SettingsAction.JumpDashBoard -> actualState withSideEffect {
                 setSettingsUseCase(actualState.data)
                 performNavigation {
                     jumpDashBoard()
                 }
             }
+
             SettingsAction.JumpUntimed -> actualState withSideEffect {
                 setSettingsUseCase(actualState.data)
                 performNavigation {
@@ -60,7 +60,6 @@ class SettingsReducer(
                 val imageLoader = action.context.imageLoader
                 imageLoader.memoryCache?.clear()
                 emptyPhotoDbUseCase()
-                setSettingsUseCase(SettingsData())
                 emitUserAction(SettingsAction.JumpDashBoard)
             }
 
@@ -71,7 +70,9 @@ class SettingsReducer(
             is SettingsAction.GotData ->
                 actualState.copy(data = action.data).asResult()
 
-
+            SettingsAction.ResetSettings -> actualState withSideEffect {
+                setSettingsUseCase(SettingsData())
+            }
         }
     }
 }

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsScreen.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsScreen.kt
@@ -35,7 +35,7 @@ fun SettingsScreen(uiState: SettingsUiState) {
         { mod -> TitleSettingsEntry(mod, uiState.jumpBack) },
         { mod -> IPAddressesSettingsEntry(mod, uiState) },
         { mod -> VisualiseSettingsEntry(mod, uiState) },
-        { mod -> CacheSettingsEntry(mod, uiState.clearCache) },
+        { mod -> CacheSettingsEntry(mod, uiState) },
         { mod -> ServerStatisticsSettingsEntry(mod, uiState) },
         { mod -> ViewUntimedSettingsEntry(mod, uiState) },
     )

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsUiState.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsUiState.kt
@@ -16,4 +16,5 @@ data class SettingsUiState(
     val setIpv6: (String) -> Unit,
     val toggleViewInHD: () -> Unit,
     val jumpUntimed: () -> Unit,
+    val jumpDashBoard: () -> Unit
 ) : PresenterUiState

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsUiState.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/SettingsUiState.kt
@@ -16,5 +16,6 @@ data class SettingsUiState(
     val setIpv6: (String) -> Unit,
     val toggleViewInHD: () -> Unit,
     val jumpUntimed: () -> Unit,
-    val jumpDashBoard: () -> Unit
+    val jumpDashBoard: () -> Unit,
+    val resetData: () -> Unit,
 ) : PresenterUiState

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/entries/CacheSettingsEntry.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/entries/CacheSettingsEntry.kt
@@ -1,6 +1,5 @@
 package studio.lunabee.amicrogallery.settings.entries
 
-import android.content.Context
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,22 +12,31 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import studio.lunabee.amicrogallery.android.core.ui.theme.MicroGalleryTheme.typography
 import studio.lunabee.amicrogallery.app.R
+import studio.lunabee.amicrogallery.settings.SettingsUiState
 
 @Composable
-fun CacheSettingsEntry(modifier: Modifier = Modifier, clearCache: (Context) -> Unit) {
+fun CacheSettingsEntry(modifier: Modifier = Modifier, uiState: SettingsUiState) {
     val context = LocalContext.current
+    Text(
+        text = stringResource(R.string.cache_and_settings),
+        style = typography.title,
+    )
     Row(
         modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
+        horizontalArrangement = Arrangement.SpaceEvenly,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(
-            text = stringResource(R.string.cache),
-            style = typography.title,
-        )
+        Button(
+            onClick = uiState.resetData,
+        ) {
+            Text(
+                text = stringResource(R.string.reset_data),
+                style = typography.body,
+            )
+        }
 
         Button(
-            onClick = { clearCache(context) },
+            onClick = { uiState.clearCache(context) },
         ) {
             Text(
                 text = stringResource(R.string.empty_cache),

--- a/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/entries/ViewUntimedSettingsEntry.kt
+++ b/microGallery_Android/app/src/main/kotlin/studio/lunabee/amicrogallery/settings/entries/ViewUntimedSettingsEntry.kt
@@ -1,11 +1,10 @@
 package studio.lunabee.amicrogallery.settings.entries
 
-import androidx.compose.material3.Button
-
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier

--- a/microGallery_Android/app/src/main/res/values/strings.xml
+++ b/microGallery_Android/app/src/main/res/values/strings.xml
@@ -57,4 +57,7 @@
     <string name="view_untimed">View</string>
     <string name="view_date_less">View date less pictures</string>
     <string name="pictures_without_date">Pictures without timestamp</string>
+    <string name="year_found">found : %s</string>
+    <string name="reset_data">Restore defaults</string>
+    <string name="cache_and_settings">Reset settings and cache</string>
 </resources>

--- a/microGallery_KMP/data/src/commonMain/kotlin/studio/lunabee/microgallery/android/data/SettingsData.kt
+++ b/microGallery_KMP/data/src/commonMain/kotlin/studio/lunabee/microgallery/android/data/SettingsData.kt
@@ -1,8 +1,8 @@
 package studio.lunabee.microgallery.android.data
 
 data class SettingsData(
-    val ipv4: String,
-    val ipv6: String,
-    val useIpv6: Boolean,
-    val viewInHD: Boolean,
+    val ipv4: String = "92.150.239.130",
+    val ipv6: String = "2a01:cb1c:82c7:5e00:9f05:da30:3fcf:58ac",
+    val useIpv6: Boolean = false,
+    val viewInHD: Boolean = true,
 )

--- a/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/SettingsDataRepository.kt
+++ b/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/SettingsDataRepository.kt
@@ -1,7 +1,6 @@
 package studio.lunabee.microgallery.android.domain
 
 import kotlinx.coroutines.flow.Flow
-import studio.lunabee.microgallery.android.data.RemoteStatus
 import studio.lunabee.microgallery.android.data.SettingsData
 
 interface SettingsDataRepository {

--- a/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/SettingsDataRepository.kt
+++ b/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/SettingsDataRepository.kt
@@ -1,0 +1,11 @@
+package studio.lunabee.microgallery.android.domain
+
+import kotlinx.coroutines.flow.Flow
+import studio.lunabee.microgallery.android.data.RemoteStatus
+import studio.lunabee.microgallery.android.data.SettingsData
+
+interface SettingsDataRepository {
+    fun getSettingsData(): Flow<SettingsData>
+    suspend fun clearSettingsDB()
+    suspend fun setSettingsData(settingsUiData: SettingsData)
+}

--- a/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/loading/LoadingRepository.kt
+++ b/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/loading/LoadingRepository.kt
@@ -8,5 +8,7 @@ interface LoadingRepository {
 
     fun getRootDir(): Flow<Directory>
     suspend fun pictureDbFreshStart()
+
+    suspend fun isPictureDbEmpty() : Boolean
     suspend fun savePicturesInDb(pictures: List<Picture>)
 }

--- a/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/loading/LoadingRepository.kt
+++ b/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/loading/LoadingRepository.kt
@@ -2,13 +2,14 @@ package studio.lunabee.microgallery.android.domain.loading
 
 import kotlinx.coroutines.flow.Flow
 import studio.lunabee.microgallery.android.data.Directory
+import studio.lunabee.microgallery.android.data.MYear
 import studio.lunabee.microgallery.android.data.Picture
 
 interface LoadingRepository {
-
-    fun getRootDir(): Flow<Directory>
+    suspend fun getYears(): List<MYear>
+    fun getYearsAsFlow(years: List<MYear>): Flow<Directory>
+    fun yearsInDb(): Flow<List<MYear>>
     suspend fun pictureDbFreshStart()
-
-    suspend fun isPictureDbEmpty() : Boolean
+    suspend fun isPictureDbEmpty(): Boolean
     suspend fun savePicturesInDb(pictures: List<Picture>)
 }

--- a/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/loading/usecase/ListYearsFlowUseCase.kt
+++ b/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/loading/usecase/ListYearsFlowUseCase.kt
@@ -1,0 +1,13 @@
+package studio.lunabee.microgallery.android.domain.loading.usecase
+
+import kotlinx.coroutines.flow.Flow
+import studio.lunabee.microgallery.android.data.MYear
+import studio.lunabee.microgallery.android.domain.loading.LoadingRepository
+
+class ListYearsFlowUseCase(
+    val loadingRepository: LoadingRepository,
+) {
+    operator fun invoke(): Flow<List<MYear>> {
+        return loadingRepository.yearsInDb()
+    }
+}

--- a/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/loading/usecase/PhotoDbIsEmptyUseCase.kt
+++ b/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/loading/usecase/PhotoDbIsEmptyUseCase.kt
@@ -3,9 +3,9 @@ package studio.lunabee.microgallery.android.domain.loading.usecase
 import studio.lunabee.microgallery.android.domain.loading.LoadingRepository
 
 class PhotoDbIsEmptyUseCase(
-    val loadingRepository: LoadingRepository
+    val loadingRepository: LoadingRepository,
 ) {
-    suspend operator fun invoke() : Boolean {
+    suspend operator fun invoke(): Boolean {
         return loadingRepository.isPictureDbEmpty()
     }
 }

--- a/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/loading/usecase/PhotoDbIsEmptyUseCase.kt
+++ b/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/loading/usecase/PhotoDbIsEmptyUseCase.kt
@@ -1,0 +1,11 @@
+package studio.lunabee.microgallery.android.domain.loading.usecase
+
+import studio.lunabee.microgallery.android.domain.loading.LoadingRepository
+
+class PhotoDbIsEmptyUseCase(
+    val loadingRepository: LoadingRepository
+) {
+    suspend operator fun invoke() : Boolean {
+        return loadingRepository.isPictureDbEmpty()
+    }
+}

--- a/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/loading/usecase/UpdateTreeUseCase.kt
+++ b/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/loading/usecase/UpdateTreeUseCase.kt
@@ -1,7 +1,8 @@
 package studio.lunabee.microgallery.android.domain.loading.usecase
 
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.Flow
 import studio.lunabee.microgallery.android.data.Directory
+import studio.lunabee.microgallery.android.data.MYear
 import studio.lunabee.microgallery.android.data.Picture
 import studio.lunabee.microgallery.android.domain.loading.LoadingRepository
 
@@ -10,14 +11,15 @@ class UpdateTreeUseCase(
     val loadingRepository: LoadingRepository,
 ) {
     suspend operator fun invoke() {
-        val rootDir = loadingRepository.getRootDir().first()
         loadingRepository.pictureDbFreshStart()
-        rootDir.content.filterIsInstance<Directory>().forEach { yearDir ->
-            if (yearDir.name == "untimed") {
-                loadingRepository.savePicturesInDb(yearDir.content.map { it as Picture })
+        val years: List<MYear> = loadingRepository.getYears()
+        val yearsFlow: Flow<Directory> = loadingRepository.getYearsAsFlow(years)
+        yearsFlow.collect { yearDir ->
+            if (yearDir.name.substringAfterLast('/') == "untimed") {
+                loadingRepository.savePicturesInDb(yearDir.content.filterIsInstance<Picture>())
             } else {
                 yearDir.content.filterIsInstance<Directory>().forEach { monthDir ->
-                    loadingRepository.savePicturesInDb(monthDir.content.map { it as Picture })
+                    loadingRepository.savePicturesInDb(monthDir.content.filterIsInstance<Picture>())
                 }
             }
         }

--- a/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/settings/SettingsRepository.kt
+++ b/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/settings/SettingsRepository.kt
@@ -2,11 +2,9 @@ package studio.lunabee.microgallery.android.domain.settings
 
 import kotlinx.coroutines.flow.Flow
 import studio.lunabee.microgallery.android.data.RemoteStatus
-import studio.lunabee.microgallery.android.data.SettingsData
 
 interface SettingsRepository {
 
     fun getStatus(): Flow<RemoteStatus>
     suspend fun clearPictureDB()
-
 }

--- a/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/settings/SettingsRepository.kt
+++ b/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/settings/SettingsRepository.kt
@@ -6,7 +6,7 @@ import studio.lunabee.microgallery.android.data.SettingsData
 
 interface SettingsRepository {
 
-    fun getSettingsData(): Flow<SettingsData>
     fun getStatus(): Flow<RemoteStatus>
-    suspend fun setSettingsData(settingsUiData: SettingsData)
+    suspend fun clearPictureDB()
+
 }

--- a/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/settings/usecase/EmptyPhotoDbUseCase.kt
+++ b/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/settings/usecase/EmptyPhotoDbUseCase.kt
@@ -1,10 +1,9 @@
 package studio.lunabee.microgallery.android.domain.settings.usecase
 
-import studio.lunabee.microgallery.android.domain.loading.LoadingRepository
 import studio.lunabee.microgallery.android.domain.settings.SettingsRepository
 
 class EmptyPhotoDbUseCase(
-    val settingsRepository: SettingsRepository
+    val settingsRepository: SettingsRepository,
 ) {
     suspend operator fun invoke() {
         return settingsRepository.clearPictureDB()

--- a/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/settings/usecase/EmptyPhotoDbUseCase.kt
+++ b/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/settings/usecase/EmptyPhotoDbUseCase.kt
@@ -1,0 +1,12 @@
+package studio.lunabee.microgallery.android.domain.settings.usecase
+
+import studio.lunabee.microgallery.android.domain.loading.LoadingRepository
+import studio.lunabee.microgallery.android.domain.settings.SettingsRepository
+
+class EmptyPhotoDbUseCase(
+    val settingsRepository: SettingsRepository
+) {
+    suspend operator fun invoke() {
+        return settingsRepository.clearPictureDB()
+    }
+}

--- a/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/settings/usecase/ObserveSettingsUseCase.kt
+++ b/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/settings/usecase/ObserveSettingsUseCase.kt
@@ -1,13 +1,16 @@
 package studio.lunabee.microgallery.android.domain.settings.usecase
 
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 import studio.lunabee.microgallery.android.data.SettingsData
+import studio.lunabee.microgallery.android.domain.SettingsDataRepository
 import studio.lunabee.microgallery.android.domain.settings.SettingsRepository
 
 class ObserveSettingsUseCase(
-    val settingsRepository: SettingsRepository,
+    val settingsDataRepository: SettingsDataRepository,
 ) {
     operator fun invoke(): Flow<SettingsData> {
-        return settingsRepository.getSettingsData()
+        return settingsDataRepository.getSettingsData()
     }
 }

--- a/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/settings/usecase/ObserveSettingsUseCase.kt
+++ b/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/settings/usecase/ObserveSettingsUseCase.kt
@@ -1,11 +1,8 @@
 package studio.lunabee.microgallery.android.domain.settings.usecase
 
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.launch
 import studio.lunabee.microgallery.android.data.SettingsData
 import studio.lunabee.microgallery.android.domain.SettingsDataRepository
-import studio.lunabee.microgallery.android.domain.settings.SettingsRepository
 
 class ObserveSettingsUseCase(
     val settingsDataRepository: SettingsDataRepository,

--- a/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/settings/usecase/SetSettingsUseCase.kt
+++ b/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/settings/usecase/SetSettingsUseCase.kt
@@ -2,11 +2,9 @@ package studio.lunabee.microgallery.android.domain.settings.usecase
 
 import studio.lunabee.microgallery.android.data.SettingsData
 import studio.lunabee.microgallery.android.domain.SettingsDataRepository
-import studio.lunabee.microgallery.android.domain.loading.LoadingRepository
-import studio.lunabee.microgallery.android.domain.settings.SettingsRepository
 
 class SetSettingsUseCase(
-    val settingsDataRepository: SettingsDataRepository
+    val settingsDataRepository: SettingsDataRepository,
 ) {
     suspend operator fun invoke(settingsData: SettingsData) {
         return settingsDataRepository.setSettingsData(settingsData)

--- a/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/settings/usecase/SetSettingsUseCase.kt
+++ b/microGallery_KMP/domain/src/commonMain/kotlin/studio/lunabee/microgallery/android/domain/settings/usecase/SetSettingsUseCase.kt
@@ -1,0 +1,14 @@
+package studio.lunabee.microgallery.android.domain.settings.usecase
+
+import studio.lunabee.microgallery.android.data.SettingsData
+import studio.lunabee.microgallery.android.domain.SettingsDataRepository
+import studio.lunabee.microgallery.android.domain.loading.LoadingRepository
+import studio.lunabee.microgallery.android.domain.settings.SettingsRepository
+
+class SetSettingsUseCase(
+    val settingsDataRepository: SettingsDataRepository
+) {
+    suspend operator fun invoke(settingsData: SettingsData) {
+        return settingsDataRepository.setSettingsData(settingsData)
+    }
+}

--- a/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/RoomAppDatabase.kt
+++ b/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/RoomAppDatabase.kt
@@ -12,6 +12,7 @@ import studio.lunabee.amicrogallery.android.local.dao.SettingsDao
 import studio.lunabee.amicrogallery.android.local.entity.PictureEntity
 import studio.lunabee.amicrogallery.android.local.entity.SettingsEntity
 import studio.lunabee.amicrogallery.android.local.entity.SettingsTable
+import studio.lunabee.microgallery.android.data.SettingsData
 import kotlin.coroutines.CoroutineContext
 
 @Database(
@@ -55,7 +56,7 @@ fun buildRoomDatabase(
 
                 override fun onCreate(connection: SQLiteConnection) {
                     super.onCreate(connection)
-                    val settingsEntity = SettingsEntity()
+                    val settingsEntity = SettingsEntity.fromSettingsData(SettingsData())
                     // this is executed only when the app is first launched after install
                     connection.execSQL(
                         "INSERT INTO $SettingsTable (ipvfour, ipvsix, useIpvSix, viewInHD)" +

--- a/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/dao/PictureDao.kt
+++ b/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/dao/PictureDao.kt
@@ -45,4 +45,7 @@ interface PictureDao {
 
     @Query("SELECT * FROM $PhotosTable WHERE scale = (SELECT MIN(scale) FROM $PhotosTable WHERE scale > :scale)")
     suspend fun getFirstPictureAfter(scale: Float): PictureEntity
+    @Query("SELECT EXISTS(SELECT * FROM PhotosTable LIMIT 1) FROM PhotosTable LIMIT 1")
+    suspend fun isThereAnyPicture() : Boolean
+
 }

--- a/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/dao/PictureDao.kt
+++ b/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/dao/PictureDao.kt
@@ -45,7 +45,7 @@ interface PictureDao {
 
     @Query("SELECT * FROM $PhotosTable WHERE scale = (SELECT MIN(scale) FROM $PhotosTable WHERE scale > :scale)")
     suspend fun getFirstPictureAfter(scale: Float): PictureEntity
-    @Query("SELECT EXISTS(SELECT * FROM PhotosTable LIMIT 1) FROM PhotosTable LIMIT 1")
-    suspend fun isThereAnyPicture() : Boolean
 
+    @Query("SELECT EXISTS(SELECT * FROM PhotosTable LIMIT 1) FROM PhotosTable LIMIT 1")
+    suspend fun isThereAnyPicture(): Boolean
 }

--- a/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/dao/SettingsDao.kt
+++ b/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/dao/SettingsDao.kt
@@ -11,7 +11,7 @@ import studio.lunabee.amicrogallery.android.local.entity.SettingsTable
 @Dao
 interface SettingsDao {
     @Query("SELECT * FROM $SettingsTable")
-    fun getSettings(): Flow<SettingsEntity> // flow will emit at each store called
+    fun getSettings(): Flow<SettingsEntity?> // flow will emit at each store called
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun storeSettings(settingsEntity: SettingsEntity)

--- a/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/datasource/PictureLocalDatasource.kt
+++ b/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/datasource/PictureLocalDatasource.kt
@@ -72,6 +72,10 @@ class PictureLocalDatasource(
         }
     }
 
+    override fun yearList(): Flow<List<MYear>> {
+        return pictureDao.getYears()
+    }
+
     override suspend fun getOrderById(id: Long): Float {
         return pictureDao.getOrderById(id)
     }

--- a/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/datasource/PictureLocalDatasource.kt
+++ b/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/datasource/PictureLocalDatasource.kt
@@ -83,4 +83,8 @@ class PictureLocalDatasource(
     override suspend fun getFirstPictureAfter(order: Float): MicroPicture {
         return pictureDao.getFirstPictureAfter(order).toMicroPicture(settingsData.first())
     }
+
+    override suspend fun isDbEmpty(): Boolean {
+        return !pictureDao.isThereAnyPicture()
+    }
 }

--- a/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/datasource/SettingsLocalDatasource.kt
+++ b/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/datasource/SettingsLocalDatasource.kt
@@ -12,7 +12,13 @@ class SettingsLocalDatasource(
 ) : SettingsLocal {
 
     override fun getSettings(): Flow<SettingsData> {
-        return settingsDao.getSettings().map { it.toSettingsData() }
+        return settingsDao.getSettings().map {
+            if(it == null) {
+                storeSettings(SettingsData())
+                SettingsData()
+            } else
+                it.toSettingsData()
+        }
     }
 
     override suspend fun storeSettings(settingsData: SettingsData) {

--- a/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/datasource/SettingsLocalDatasource.kt
+++ b/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/datasource/SettingsLocalDatasource.kt
@@ -13,11 +13,12 @@ class SettingsLocalDatasource(
 
     override fun getSettings(): Flow<SettingsData> {
         return settingsDao.getSettings().map {
-            if(it == null) {
+            if (it == null) {
                 storeSettings(SettingsData())
                 SettingsData()
-            } else
+            } else {
                 it.toSettingsData()
+            }
         }
     }
 

--- a/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/entity/SettingsEntity.kt
+++ b/microGallery_KMP/local/src/commonMain/kotlin/studio/lunabee/amicrogallery/android/local/entity/SettingsEntity.kt
@@ -11,11 +11,11 @@ const val SettingsTable = "SettingsTable"
     tableName = SettingsTable,
 )
 data class SettingsEntity(
-    @PrimaryKey @ColumnInfo(name = "id") val id: Long = 4871L, // magic number
-    @ColumnInfo(name = "ipvsix") val ipv6: String = "2a01:cb1c:82c7:5e00:9f05:da30:3fcf:58ac",
-    @ColumnInfo(name = "ipvfour") val ipv4: String = "92.150.239.130",
-    @ColumnInfo(name = "viewInHD") val viewInHD: Boolean = true,
-    @ColumnInfo(name = "useIpvSix") val useIpv6: Boolean = false,
+    @PrimaryKey @ColumnInfo(name = "id") val id: Long = 4871L, // magic number to keep unicity
+    @ColumnInfo(name = "ipvsix") val ipv6: String,
+    @ColumnInfo(name = "ipvfour") val ipv4: String,
+    @ColumnInfo(name = "viewInHD") val viewInHD: Boolean,
+    @ColumnInfo(name = "useIpvSix") val useIpv6: Boolean,
 ) {
     fun toSettingsData(): SettingsData {
         return SettingsData(

--- a/microGallery_KMP/remote/src/commonMain/kotlin/studio/lunabee/microgallery/android/remote/datasource/RemoteStatusDatasourceImpl.kt
+++ b/microGallery_KMP/remote/src/commonMain/kotlin/studio/lunabee/microgallery/android/remote/datasource/RemoteStatusDatasourceImpl.kt
@@ -9,7 +9,6 @@ import studio.lunabee.microgallery.android.repository.datasource.remote.RemoteSt
 class RemoteStatusDatasourceImpl(
     private val rootService: RootService,
 ) : RemoteStatusDatasource {
-
     override fun fetchStatus(): Flow<RemoteStatus> {
         return rootService.fetchStatus().map { it.toRemoteStatus() }
     }

--- a/microGallery_KMP/remote/src/commonMain/kotlin/studio/lunabee/microgallery/android/remote/model/RemoteMicroElement.kt
+++ b/microGallery_KMP/remote/src/commonMain/kotlin/studio/lunabee/microgallery/android/remote/model/RemoteMicroElement.kt
@@ -16,11 +16,10 @@ data class RemoteMicroElement(
         return when (type) {
             "directory" -> Directory(
                 name = name,
-                content = (contents?.map { it.toData() })!!,
+                content = (contents ?: emptyList()).map { it.toData() },
             )
 
             "file" -> Picture(
-                id = 4L,
                 name = name,
                 fullResPath = null,
                 lowResPath = null,

--- a/microGallery_KMP/remote/src/commonMain/kotlin/studio/lunabee/microgallery/android/remote/service/RootService.kt
+++ b/microGallery_KMP/remote/src/commonMain/kotlin/studio/lunabee/microgallery/android/remote/service/RootService.kt
@@ -4,6 +4,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import studio.lunabee.microgallery.android.data.MYear
 import studio.lunabee.microgallery.android.remote.CoreHttpClient
 import studio.lunabee.microgallery.android.remote.model.BashRemoteStatus
 import studio.lunabee.microgallery.android.remote.model.RemoteMicroElement
@@ -11,9 +12,15 @@ import studio.lunabee.microgallery.android.remote.model.RemoteMicroElement
 class RootService(
     private val coreHttpClient: CoreHttpClient,
 ) {
-    fun fetchRootList(): Flow<List<RemoteMicroElement>> {
+    suspend fun fetchYearList(): List<MYear> {
+        return coreHttpClient.httpClient.get("/commande/treeJSON?all=True").body()
+    }
+
+    fun fetchYears(yearList: List<MYear>): Flow<List<RemoteMicroElement>> {
         return flow {
-            emit(coreHttpClient.httpClient.get("/commande/treeJSON").body())
+            yearList.forEach {
+                emit(coreHttpClient.httpClient.get("/commande/treeJSON?year=$it").body())
+            }
         }
     }
 

--- a/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/amicrogallery/picture/PictureLocal.kt
+++ b/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/amicrogallery/picture/PictureLocal.kt
@@ -15,8 +15,10 @@ interface PictureLocal {
     fun getPicturesInMonth(year: MYear, month: MMonth): Flow<List<MicroPicture>>
     fun getPicturesUntimed(): Flow<List<MicroPicture>>
     fun getPictureById(id: Long): Flow<MicroPicture>
+
+    fun yearList(): Flow<List<MYear>>
     suspend fun getOrderById(id: Long): Float
     suspend fun getFirstPictureBefore(order: Float): MicroPicture
     suspend fun getFirstPictureAfter(order: Float): MicroPicture
-    suspend fun isDbEmpty() : Boolean
+    suspend fun isDbEmpty(): Boolean
 }

--- a/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/amicrogallery/picture/PictureLocal.kt
+++ b/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/amicrogallery/picture/PictureLocal.kt
@@ -18,4 +18,5 @@ interface PictureLocal {
     suspend fun getOrderById(id: Long): Float
     suspend fun getFirstPictureBefore(order: Float): MicroPicture
     suspend fun getFirstPictureAfter(order: Float): MicroPicture
+    suspend fun isDbEmpty() : Boolean
 }

--- a/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/microgallery/android/repository/datasource/remote/TreeRemoteDatasource.kt
+++ b/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/microgallery/android/repository/datasource/remote/TreeRemoteDatasource.kt
@@ -2,8 +2,9 @@ package studio.lunabee.microgallery.android.repository.datasource.remote
 
 import kotlinx.coroutines.flow.Flow
 import studio.lunabee.microgallery.android.data.Directory
+import studio.lunabee.microgallery.android.data.MYear
 
 interface TreeRemoteDatasource {
-
-    fun getRoot(): Flow<Directory>
+    suspend fun getYears(): List<MYear>
+    fun getYearDirs(years: List<MYear>): Flow<Directory>
 }

--- a/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/microgallery/android/repository/impl/LoadingRepositoryImpl.kt
+++ b/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/microgallery/android/repository/impl/LoadingRepositoryImpl.kt
@@ -20,6 +20,10 @@ class LoadingRepositoryImpl(
         pictureLocal.freshStart()
     }
 
+    override suspend fun isPictureDbEmpty() : Boolean {
+        return pictureLocal.isDbEmpty()
+    }
+
     override suspend fun savePicturesInDb(pictures: List<Picture>) {
         pictureLocal.insertPictures(pictures)
     }

--- a/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/microgallery/android/repository/impl/LoadingRepositoryImpl.kt
+++ b/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/microgallery/android/repository/impl/LoadingRepositoryImpl.kt
@@ -3,6 +3,7 @@ package studio.lunabee.microgallery.android.repository.impl
 import kotlinx.coroutines.flow.Flow
 import studio.lunabee.amicrogallery.picture.PictureLocal
 import studio.lunabee.microgallery.android.data.Directory
+import studio.lunabee.microgallery.android.data.MYear
 import studio.lunabee.microgallery.android.data.Picture
 import studio.lunabee.microgallery.android.domain.loading.LoadingRepository
 import studio.lunabee.microgallery.android.repository.datasource.remote.TreeRemoteDatasource
@@ -11,16 +12,23 @@ class LoadingRepositoryImpl(
     val treeRemoteDatasource: TreeRemoteDatasource,
     val pictureLocal: PictureLocal,
 ) : LoadingRepository {
+    override suspend fun getYears(): List<MYear> {
+        return treeRemoteDatasource.getYears()
+    }
 
-    override fun getRootDir(): Flow<Directory> {
-        return treeRemoteDatasource.getRoot()
+    override fun getYearsAsFlow(years: List<MYear>): Flow<Directory> {
+        return treeRemoteDatasource.getYearDirs(years)
+    }
+
+    override fun yearsInDb(): Flow<List<MYear>> {
+        return pictureLocal.yearList()
     }
 
     override suspend fun pictureDbFreshStart() {
         pictureLocal.freshStart()
     }
 
-    override suspend fun isPictureDbEmpty() : Boolean {
+    override suspend fun isPictureDbEmpty(): Boolean {
         return pictureLocal.isDbEmpty()
     }
 

--- a/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/microgallery/android/repository/impl/SettingsDataRepositoryImpl.kt
+++ b/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/microgallery/android/repository/impl/SettingsDataRepositoryImpl.kt
@@ -1,17 +1,12 @@
 package studio.lunabee.microgallery.android.repository.impl
 
 import kotlinx.coroutines.flow.Flow
-import studio.lunabee.amicrogallery.picture.PictureLocal
 import studio.lunabee.amicrogallery.settings.SettingsLocal
-import studio.lunabee.microgallery.android.data.RemoteStatus
 import studio.lunabee.microgallery.android.data.SettingsData
 import studio.lunabee.microgallery.android.domain.SettingsDataRepository
-import studio.lunabee.microgallery.android.domain.settings.SettingsRepository
-import studio.lunabee.microgallery.android.repository.datasource.remote.RemoteStatusDatasource
 
 class SettingsDataRepositoryImpl(
     private val settingsLocal: SettingsLocal,
-    private val remoteStatusDatasource: RemoteStatusDatasource,
 ) : SettingsDataRepository {
 
     override fun getSettingsData(): Flow<SettingsData> {

--- a/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/microgallery/android/repository/impl/SettingsDataRepositoryImpl.kt
+++ b/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/microgallery/android/repository/impl/SettingsDataRepositoryImpl.kt
@@ -5,21 +5,24 @@ import studio.lunabee.amicrogallery.picture.PictureLocal
 import studio.lunabee.amicrogallery.settings.SettingsLocal
 import studio.lunabee.microgallery.android.data.RemoteStatus
 import studio.lunabee.microgallery.android.data.SettingsData
+import studio.lunabee.microgallery.android.domain.SettingsDataRepository
 import studio.lunabee.microgallery.android.domain.settings.SettingsRepository
 import studio.lunabee.microgallery.android.repository.datasource.remote.RemoteStatusDatasource
 
-class SettingsRepositoryImpl(
+class SettingsDataRepositoryImpl(
     private val settingsLocal: SettingsLocal,
-    private val pictureLocal: PictureLocal,
     private val remoteStatusDatasource: RemoteStatusDatasource,
-) : SettingsRepository {
+) : SettingsDataRepository {
 
-    override fun getStatus(): Flow<RemoteStatus> {
-        return remoteStatusDatasource.fetchStatus()
+    override fun getSettingsData(): Flow<SettingsData> {
+        return settingsLocal.getSettings()
     }
 
-    override suspend fun clearPictureDB() {
-        pictureLocal.freshStart()
+    override suspend fun clearSettingsDB() {
+        settingsLocal.storeSettings(SettingsData()) // put default settings data
     }
 
+    override suspend fun setSettingsData(settingsUiData: SettingsData) {
+        settingsLocal.storeSettings(settingsUiData)
+    }
 }

--- a/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/microgallery/android/repository/impl/SettingsRepositoryImpl.kt
+++ b/microGallery_KMP/repository/src/commonMain/kotlin/studio/lunabee/microgallery/android/repository/impl/SettingsRepositoryImpl.kt
@@ -2,14 +2,11 @@ package studio.lunabee.microgallery.android.repository.impl
 
 import kotlinx.coroutines.flow.Flow
 import studio.lunabee.amicrogallery.picture.PictureLocal
-import studio.lunabee.amicrogallery.settings.SettingsLocal
 import studio.lunabee.microgallery.android.data.RemoteStatus
-import studio.lunabee.microgallery.android.data.SettingsData
 import studio.lunabee.microgallery.android.domain.settings.SettingsRepository
 import studio.lunabee.microgallery.android.repository.datasource.remote.RemoteStatusDatasource
 
 class SettingsRepositoryImpl(
-    private val settingsLocal: SettingsLocal,
     private val pictureLocal: PictureLocal,
     private val remoteStatusDatasource: RemoteStatusDatasource,
 ) : SettingsRepository {
@@ -21,5 +18,4 @@ class SettingsRepositoryImpl(
     override suspend fun clearPictureDB() {
         pictureLocal.freshStart()
     }
-
 }

--- a/microGallery_KMP/shared/src/androidMain/kotlin/studio/lunabee/amicrogallery/android/shared/RepositoryModule.kt
+++ b/microGallery_KMP/shared/src/androidMain/kotlin/studio/lunabee/amicrogallery/android/shared/RepositoryModule.kt
@@ -4,7 +4,6 @@ import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
-import studio.lunabee.microgallery.android.data.SettingsData
 import studio.lunabee.microgallery.android.domain.SettingsDataRepository
 import studio.lunabee.microgallery.android.domain.calendar.CalendarRepository
 import studio.lunabee.microgallery.android.domain.lastMonth.LastMonthRepository

--- a/microGallery_KMP/shared/src/androidMain/kotlin/studio/lunabee/amicrogallery/android/shared/RepositoryModule.kt
+++ b/microGallery_KMP/shared/src/androidMain/kotlin/studio/lunabee/amicrogallery/android/shared/RepositoryModule.kt
@@ -4,6 +4,8 @@ import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
+import studio.lunabee.microgallery.android.data.SettingsData
+import studio.lunabee.microgallery.android.domain.SettingsDataRepository
 import studio.lunabee.microgallery.android.domain.calendar.CalendarRepository
 import studio.lunabee.microgallery.android.domain.lastMonth.LastMonthRepository
 import studio.lunabee.microgallery.android.domain.loading.LoadingRepository
@@ -14,6 +16,7 @@ import studio.lunabee.microgallery.android.repository.impl.CalendarRepositoryImp
 import studio.lunabee.microgallery.android.repository.impl.LastMonthRepositoryImpl
 import studio.lunabee.microgallery.android.repository.impl.LoadingRepositoryImpl
 import studio.lunabee.microgallery.android.repository.impl.PhotoViewerRepositoryImpl
+import studio.lunabee.microgallery.android.repository.impl.SettingsDataRepositoryImpl
 import studio.lunabee.microgallery.android.repository.impl.SettingsRepositoryImpl
 import studio.lunabee.microgallery.android.repository.impl.UntimedRepositoryImpl
 
@@ -24,4 +27,5 @@ val repositoryModule = module {
     singleOf(::LastMonthRepositoryImpl) bind LastMonthRepository::class
     factoryOf(::PhotoViewerRepositoryImpl) bind PhotoViewerRepository::class
     singleOf(::SettingsRepositoryImpl) bind SettingsRepository::class
+    singleOf(::SettingsDataRepositoryImpl) bind SettingsDataRepository::class
 }

--- a/microGallery_KMP/shared/src/androidMain/kotlin/studio/lunabee/amicrogallery/android/shared/UseCaseModule.kt
+++ b/microGallery_KMP/shared/src/androidMain/kotlin/studio/lunabee/amicrogallery/android/shared/UseCaseModule.kt
@@ -5,11 +5,14 @@ import org.koin.dsl.module
 import studio.lunabee.microgallery.android.domain.calendar.usecase.LoadPartialTreeUseCase
 import studio.lunabee.microgallery.android.domain.calendar.usecase.ObserveYearPreviewsUseCase
 import studio.lunabee.microgallery.android.domain.lastMonth.usecase.ObserveLastMonthUseCase
+import studio.lunabee.microgallery.android.domain.loading.usecase.PhotoDbIsEmptyUseCase
 import studio.lunabee.microgallery.android.domain.loading.usecase.UpdateTreeUseCase
 import studio.lunabee.microgallery.android.domain.photoviewer.usecase.GetNeighborsByPictureUseCase
 import studio.lunabee.microgallery.android.domain.photoviewer.usecase.ObservePictureByIdUseCase
+import studio.lunabee.microgallery.android.domain.settings.usecase.EmptyPhotoDbUseCase
 import studio.lunabee.microgallery.android.domain.settings.usecase.ObserveSettingsUseCase
 import studio.lunabee.microgallery.android.domain.settings.usecase.ObserveStatusUseCase
+import studio.lunabee.microgallery.android.domain.settings.usecase.SetSettingsUseCase
 import studio.lunabee.microgallery.android.domain.untimed.usecase.ObserveUntimedUseCase
 
 val useCaseModule = module {
@@ -22,4 +25,7 @@ val useCaseModule = module {
     factoryOf(::UpdateTreeUseCase)
     factoryOf(::ObserveStatusUseCase)
     factoryOf(::GetNeighborsByPictureUseCase)
+    factoryOf(::PhotoDbIsEmptyUseCase)
+    factoryOf(::EmptyPhotoDbUseCase)
+    factoryOf(::SetSettingsUseCase)
 }

--- a/microGallery_KMP/shared/src/androidMain/kotlin/studio/lunabee/amicrogallery/android/shared/UseCaseModule.kt
+++ b/microGallery_KMP/shared/src/androidMain/kotlin/studio/lunabee/amicrogallery/android/shared/UseCaseModule.kt
@@ -5,6 +5,7 @@ import org.koin.dsl.module
 import studio.lunabee.microgallery.android.domain.calendar.usecase.LoadPartialTreeUseCase
 import studio.lunabee.microgallery.android.domain.calendar.usecase.ObserveYearPreviewsUseCase
 import studio.lunabee.microgallery.android.domain.lastMonth.usecase.ObserveLastMonthUseCase
+import studio.lunabee.microgallery.android.domain.loading.usecase.ListYearsFlowUseCase
 import studio.lunabee.microgallery.android.domain.loading.usecase.PhotoDbIsEmptyUseCase
 import studio.lunabee.microgallery.android.domain.loading.usecase.UpdateTreeUseCase
 import studio.lunabee.microgallery.android.domain.photoviewer.usecase.GetNeighborsByPictureUseCase
@@ -28,4 +29,5 @@ val useCaseModule = module {
     factoryOf(::PhotoDbIsEmptyUseCase)
     factoryOf(::EmptyPhotoDbUseCase)
     factoryOf(::SetSettingsUseCase)
+    factoryOf(::ListYearsFlowUseCase)
 }


### PR DESCRIPTION
## 📜 Description

The list of links is now fetched only when the db is empty.
Also, now, the remote list is not fetched all at once, but rather year by year, so that it's not too much to handle for the app

## 💡 Motivation and Context

App started crashing because of too much pictures in DB

## 💚 How did you test it?

## 📝 Checklist

* [x] 📖 I reviewed the submitted code
* [x] 🛀 I launched `./gradlew detekt`
* [ ] 📡 I checked on iOS how it was done and fill their ticket with any specific information if it's not done yet
* [ ] 🦮 I verified the accessibility (if it makes sense)
* [ ] 🏭 I implemented Unit Tests (if it makes sense)

## 🔮 Next steps

## 📸 Screenshots / GIFs
